### PR TITLE
Expose cognite client

### DIFF
--- a/ExtractorUtils.Test/CogniteTest.cs
+++ b/ExtractorUtils.Test/CogniteTest.cs
@@ -186,22 +186,22 @@ namespace ExtractorUtils.Test
             services.AddCogniteClient("testApp", true, true);
             using (var provider = services.BuildServiceProvider()) {
                 var config = provider.GetRequiredService<CogniteConfig>();
-                var cogClient = provider.GetRequiredService<Client>();
-                var ex = await Assert.ThrowsAsync<CogniteUtilsException>(() => cogClient.TestCogniteConfig(null, CancellationToken.None));
+                var cogniteDestination = provider.GetRequiredService<CogniteDestination>();
+                var ex = await Assert.ThrowsAsync<CogniteUtilsException>(() => cogniteDestination.CogniteClient.TestCogniteConfig(null, CancellationToken.None));
                 Assert.Contains("configuration missing", ex.Message);
 
                 config.Project = null;
-                ex = await Assert.ThrowsAsync<CogniteUtilsException>(() => cogClient.TestCogniteConfig(config, CancellationToken.None));
+                ex = await Assert.ThrowsAsync<CogniteUtilsException>(() => cogniteDestination.CogniteClient.TestCogniteConfig(config, CancellationToken.None));
                 Assert.Contains("project is not configured", ex.Message);
 
                 config.Project = "Bogus";
-                ex = await Assert.ThrowsAsync<CogniteUtilsException>(() => cogClient.TestCogniteConfig(config, CancellationToken.None));
+                ex = await Assert.ThrowsAsync<CogniteUtilsException>(() => cogniteDestination.CogniteClient.TestCogniteConfig(config, CancellationToken.None));
                 Assert.Contains("not associated with project Bogus", ex.Message);
                 config.Project = _project;
 
-                await cogClient.TestCogniteConfig(config, CancellationToken.None);
+                await cogniteDestination.TestCogniteConfig(CancellationToken.None);
 
-                var loginStatus = await cogClient.Login.StatusAsync(CancellationToken.None);
+                var loginStatus = await cogniteDestination.CogniteClient.Login.StatusAsync(CancellationToken.None);
                 Assert.True(loginStatus.LoggedIn);
                 Assert.Equal("testuser", loginStatus.User);
                 Assert.Equal(_project, loginStatus.Project);
@@ -210,7 +210,7 @@ namespace ExtractorUtils.Test
                 {
                     Limit = 1
                 };
-                var ts = await cogClient.TimeSeries.ListAsync(options);
+                var ts = await cogniteDestination.CogniteClient.TimeSeries.ListAsync(options);
                 Assert.Empty(ts.Items);
             }
 

--- a/ExtractorUtils.Test/ExtractorUtils.Test.csproj
+++ b/ExtractorUtils.Test/ExtractorUtils.Test.csproj
@@ -1,18 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.2.1" />
     <PackageReference Include="coverlet.msbuild" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ExtractorUtils\ExtractorUtils.csproj" />

--- a/ExtractorUtils/Cognite/CogniteDestination.cs
+++ b/ExtractorUtils/Cognite/CogniteDestination.cs
@@ -16,9 +16,15 @@ namespace Cognite.Extractor.Utils
     /// </summary>
     public class CogniteDestination
     {
-        private Client _client;
-        private ILogger<CogniteDestination> _logger;
-        private CogniteConfig _config;
+        private readonly Client _client;
+        private readonly ILogger<CogniteDestination> _logger;
+        private readonly CogniteConfig _config;
+
+        /// <summary>
+        /// The configured Cognite client used by this destination. Can be used to
+        /// access the full Cognite API
+        /// </summary>
+        public Client CogniteClient => _client;
 
         /// <summary>
         /// Initializes the Cognite destination with the provided parameters

--- a/ExtractorUtils/ExtractorUtils.csproj
+++ b/ExtractorUtils/ExtractorUtils.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,29 +12,29 @@
     </Description>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3"/>
-    <PackageReference Include="Serilog" Version="2.9.0"/>
-    <PackageReference Include="System.Text.Json" Version="4.7.1"/>
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0"/>
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1"/>
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0"/>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1"/>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3"/>
-    <PackageReference Include="prometheus-net" Version="3.5.0"/>
-    <PackageReference Include="Polly" Version="7.2.0"/>
-    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.3"/>
-    <PackageReference Include="CogniteSdk" Version="1.0.7"/>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
-    <PackageReference Include="Google.Protobuf" Version="3.11.4"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
+    <PackageReference Include="prometheus-net" Version="3.5.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.3" />
+    <PackageReference Include="CogniteSdk" Version="1.0.8" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.12.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Cognite.Config\Cognite.Configuration.csproj"/>
-    <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj"/>
-    <ProjectReference Include="..\Cognite.Metrics\Cognite.Metrics.csproj"/>
-    <ProjectReference Include="..\Cognite.Logging\Cognite.Logging.csproj"/>
+    <ProjectReference Include="..\Cognite.Config\Cognite.Configuration.csproj" />
+    <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj" />
+    <ProjectReference Include="..\Cognite.Metrics\Cognite.Metrics.csproj" />
+    <ProjectReference Include="..\Cognite.Logging\Cognite.Logging.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The SDK client is now exposed as a property of the CogniteDestination. This way, a new client does not have to be created by the extractors (in case they need to access the full API)
Also, bump dependencies