### PR TITLE
Remove GenerateDefaults from Configuration

### DIFF
--- a/ExtractorUtils/Configuration/Configuration.cs
+++ b/ExtractorUtils/Configuration/Configuration.cs
@@ -30,7 +30,6 @@ namespace Cognite.Extractor.Utils
         {
             var config = ConfigurationUtils.TryReadConfigFromFile<T>(path, acceptedConfigVersions);
             services.AddSingleton<T>(config);
-            config.GenerateDefaults();
             services.AddSingleton(config.Cognite);
             services.AddSingleton(config.Logger);
             services.AddSingleton(config.Metrics);


### PR DESCRIPTION
It is called from TryReadConfigFromFile, and does not need to be called twice.