### PR TITLE
Dispose LiteDatabase object

### DIFF
--- a/Cognite.StateStorage/IExtractionStateStore.cs
+++ b/Cognite.StateStorage/IExtractionStateStore.cs
@@ -8,7 +8,7 @@ namespace Cognite.Extractor.StateStorage
     /// <summary>
     /// Represents a general extractor state store, for storing first/last timestamps.
     /// </summary>
-    public interface IExtractionStateStore
+    public interface IExtractionStateStore : IDisposable
     {
         /// <summary>
         /// Store information from states into state store

--- a/Cognite.StateStorage/LiteDBStateStore.cs
+++ b/Cognite.StateStorage/LiteDBStateStore.cs
@@ -225,5 +225,24 @@ namespace Cognite.Extractor.StateStorage
                 _logger.LogWarning("Failed to delete extraction state from store {store}: {Message}", e.Message, tableName);
             }
         }
+        /// <summary>
+        /// Dispose lite database
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _db.Dispose();
+            }
+        }
+        /// <summary>
+        /// Dispose, for lite database.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/Cognite.StateStorage/RawStateStore.cs
+++ b/Cognite.StateStorage/RawStateStore.cs
@@ -194,5 +194,11 @@ namespace Cognite.Extractor.StateStorage
                 _logger.LogWarning(e, "Failed to delete extraction state from store {store}: {Message}", e.Message, tableName);
             }
         }
+        /// <summary>
+        /// For interface, nothing that should be disposed here.
+        /// </summary>
+        public void Dispose()
+        {
+        }
     }
 }

--- a/ExtractorUtils.Test/TestUtilities.cs
+++ b/ExtractorUtils.Test/TestUtilities.cs
@@ -39,6 +39,10 @@ namespace ExtractorUtils.Test {
             return Task.CompletedTask;
         }
 
+        public void Dispose()
+        {
+        }
+
         public Task RestoreExtractionState<T, K>(IDictionary<string, K> extractionStates, string tableName, Action<K, T> restoreStorableState, CancellationToken token)
             where T : BaseStorableState
             where K : IExtractionState


### PR DESCRIPTION
This generally should not affect implementations, since we use a singleton, and it is disposed with the service provider.

Notably, this caused tests to fail on Windows, which uses a stricter file-lock than unix-based systems.

This is unlikely to affect usage as the intended pattern only ever keeps a single copy. Tests are affected, however, as the file lock is not removed between tests.