### PR TITLE
Add method to log the contents of a cognite result

### DIFF
--- a/Cognite.Extensions/LoggerExtensions.cs
+++ b/Cognite.Extensions/LoggerExtensions.cs
@@ -1,0 +1,130 @@
+﻿using CogniteSdk;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cognite.Extensions
+{
+    /// <summary>
+    /// Extensions class containing methods to log the results of extension methods
+    /// </summary>
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Log a description of the error, with how the values that caused it
+        /// as well as the number of objects that were affected by it.
+        /// </summary>
+        /// <param name="logger">Logger to log the error to</param>
+        /// <param name="error">Error to log</param>
+        /// <param name="requestType">Request that caused the error</param>
+        /// <param name="ignoreExisting">True to not log errors caused by items already present in CDF</param>
+        /// <param name="handledLevel">Log level of errors that were handled by the utils</param>
+        /// <param name="fatalLevel">Log level of errors that could not be handled and caused the request to fail</param>
+        public static void LogCogniteError(this ILogger logger,
+            CogniteError error,
+            RequestType requestType,
+            bool ignoreExisting,
+            LogLevel handledLevel = LogLevel.Debug,
+            LogLevel fatalLevel = LogLevel.Error)
+        {
+            string valueString = null;
+            if (error.Values != null && error.Values.Any())
+            {
+                valueString = string.Join(", ", error.Values.Select(idt => idt.ExternalId ?? idt.Id.ToString()));
+            }
+            string resourceName;
+            switch (requestType)
+            {
+                case RequestType.CreateAssets:
+                    resourceName = "assets";
+                    break;
+                case RequestType.CreateEvents:
+                    resourceName = "events";
+                    break;
+                case RequestType.CreateTimeSeries:
+                    resourceName = "timeseries";
+                    break;
+                default:
+                    resourceName = "unknown";
+                    break;
+            }
+            switch (error.Type)
+            {
+                case ErrorType.FatalFailure:
+                    logger.Log(fatalLevel, "Fatal error in request of type {type}: {msg}", requestType, error.Message);
+                    break;
+                case ErrorType.ItemDuplicated:
+                    logger.Log(handledLevel, "The following {resource}s were duplicated in the request: {values}, " +
+                        "resulting in the removal of {cnt} {name} from the request",
+                        error.Resource, valueString, error.Skipped?.Count() ?? 0, resourceName);
+                    break;
+                case ErrorType.ItemExists:
+                    if (ignoreExisting) return;
+                    logger.Log(handledLevel, "The following {resource}s already existed in CDF: {values}, " +
+                        "resulting in the removal of {cnt} {name} from the request",
+                        error.Resource, valueString, error.Skipped?.Count() ?? 0, resourceName);
+                    break;
+                case ErrorType.ItemMissing:
+                    logger.Log(handledLevel, "The following {resource}s were missing in CDF: {values}, " +
+                        "resulting in the removal of {cnt} {name} from the request",
+                        error.Resource, valueString, error.Skipped?.Count() ?? 0, resourceName);
+                    break;
+                case ErrorType.SanitationFailed:
+                    logger.Log(handledLevel, "Sanitation of {resource} with values: {values} failed, " +
+                        "resulting in the removal of {cnt} {name} from the request",
+                        error.Resource, valueString, error.Skipped?.Count() ?? 0, resourceName);
+                    break;
+            }
+        }
+
+
+        private static void LogCommon<T>(ILogger logger,
+            CogniteResult<T> result,
+            RequestType requestType,
+            LogLevel infoLevel,
+            LogLevel handledErrorLevel,
+            LogLevel fatalLevel,
+            bool ignoreExisting)
+        {
+            int successCount = result.Results?.Count() ?? 0;
+            int errorCount = result.Errors?.Count() ?? 0;
+
+            logger.Log(infoLevel, "Request of type {type} had {cnt} results with {cnt2} errors",
+                requestType, successCount, errorCount);
+
+            if (result.Errors != null)
+            {
+                foreach (var err in result.Errors)
+                {
+                    logger.LogCogniteError(err, requestType, ignoreExisting, handledErrorLevel, fatalLevel);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Log the CogniteResult object and all its errors.
+        /// </summary>
+        /// <typeparam name="T">Type of result</typeparam>
+        /// <param name="logger">Logger to write to</param>
+        /// <param name="result">Result to log</param>
+        /// <param name="requestType">Request type</param>
+        /// <param name="ignoreExisting">True to not log errors caused by items already present in CDF</param>
+        /// <param name="infoLevel">Level for summary information about the request</param>
+        /// <param name="handledErrorLevel">Log level of errors that were handled by the utils</param>
+        /// <param name="fatalLevel">Log level of errors that could not be handled and caused the request to fail</param>
+        public static void LogResult<T>(this ILogger logger,
+            CogniteResult<T> result,
+            RequestType requestType,
+            bool ignoreExisting,
+            LogLevel infoLevel = LogLevel.Information,
+            LogLevel handledErrorLevel = LogLevel.Debug,
+            LogLevel fatalLevel = LogLevel.Error)
+        {
+            if (result == null) throw new ArgumentNullException(nameof(result));
+
+            LogCommon(logger, result, requestType, infoLevel, handledErrorLevel, fatalLevel, ignoreExisting);
+        }
+    }
+}

--- a/ExtractorUtils.Test/AssetIntegrationTest.cs
+++ b/ExtractorUtils.Test/AssetIntegrationTest.cs
@@ -245,6 +245,8 @@ namespace ExtractorUtils.Test
             {
                 var result = await tester.Destination.EnsureAssetsExistsAsync(assets, RetryMode.OnError, SanitationMode.Remove, tester.Source.Token);
 
+                tester.Logger.LogResult(result, RequestType.CreateAssets, false);
+
                 Assert.Single(result.Results);
                 Assert.Equal(5, result.Errors.Count());
                 Assert.Equal("final-asset-ok", result.Results.First().Name);

--- a/ExtractorUtils.Test/CDFTester.cs
+++ b/ExtractorUtils.Test/CDFTester.cs
@@ -1,6 +1,8 @@
-﻿using Cognite.Extractor.Logging;
+﻿using Castle.Core.Logging;
+using Cognite.Extractor.Logging;
 using Cognite.Extractor.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading;
@@ -10,6 +12,7 @@ namespace ExtractorUtils.Test
     class CDFTester : IDisposable
     {
         private static int _configIdx;
+        public ILogger<CDFTester> Logger { get; }
         public ServiceProvider Provider { get; }
         public CogniteDestination Destination { get; }
         public CancellationTokenSource Source { get; }
@@ -28,6 +31,7 @@ namespace ExtractorUtils.Test
             services.AddLogger();
             services.AddCogniteClient("net-extractor-utils-test");
             Provider = services.BuildServiceProvider();
+            Logger = Provider.GetRequiredService<ILogger<CDFTester>>();
             Destination = Provider.GetRequiredService<CogniteDestination>();
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
             Random random = new Random();

--- a/ExtractorUtils.Test/CogniteResultTests.cs
+++ b/ExtractorUtils.Test/CogniteResultTests.cs
@@ -1,5 +1,8 @@
 ﻿using Cognite.Extensions;
+using Cognite.Extractor.Logging;
 using CogniteSdk;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +14,17 @@ namespace ExtractorUtils.Test
 {
     public class CogniteResultTests
     {
+        private ILogger<CogniteResultTests> logger;
+        public CogniteResultTests()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(new LoggerConfig
+            {
+                Console = new LogConfig { Level = "debug" }
+            });
+            services.AddLogging();
+            logger = services.BuildServiceProvider().GetRequiredService<ILogger<CogniteResultTests>>();
+        }
         [Fact]
         public void ParseUnknownException()
         {
@@ -93,6 +107,7 @@ namespace ExtractorUtils.Test
             for (int i = 0; i < exceptions.Length; i++)
             {
                 var error = ResultHandlers.ParseException(exceptions[i], RequestType.CreateAssets);
+                logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
                 assets = (await ResultHandlers.CleanFromError(null, error, assets, 1000, 1, CancellationToken.None))
                     .ToArray();
                 Assert.Equal(9 - i * 2 - 2, assets.Count());
@@ -188,6 +203,7 @@ namespace ExtractorUtils.Test
             for (int i = 0; i < exceptions.Length; i++)
             {
                 var error = ResultHandlers.ParseException(exceptions[i], RequestType.CreateTimeSeries);
+                logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
                 timeseries = (ResultHandlers.CleanFromError(error, timeseries))
                     .ToArray();
                 Assert.Equal(9 - i * 2 - 2, timeseries.Count());
@@ -261,6 +277,7 @@ namespace ExtractorUtils.Test
             for (int i = 0; i < exceptions.Length; i++)
             {
                 var error = ResultHandlers.ParseException(exceptions[i], RequestType.CreateEvents);
+                logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
                 events = (ResultHandlers.CleanFromError(error, events))
                     .ToArray();
                 Assert.Equal(7 - i * 2 - 2, events.Count());

--- a/ExtractorUtils.Test/EventIntegrationTest.cs
+++ b/ExtractorUtils.Test/EventIntegrationTest.cs
@@ -204,6 +204,8 @@ namespace ExtractorUtils.Test
             {
                 var result = await tester.Destination.EnsureEventsExistsAsync(events, RetryMode.OnError, SanitationMode.Remove, tester.Source.Token);
 
+                tester.Logger.LogResult(result, RequestType.CreateEvents, false);
+
                 Assert.Single(result.Results);
                 Assert.Equal(3, result.Errors.Count());
                 Assert.Equal($"{tester.Prefix} final-evt-ok", result.Results.First().ExternalId);

--- a/ExtractorUtils.Test/TimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/TimeSeriesIntegrationTest.cs
@@ -212,6 +212,8 @@ namespace ExtractorUtils.Test
             {
                 var result = await tester.Destination.EnsureTimeSeriesExistsAsync(timeseries, RetryMode.OnError, SanitationMode.Remove, tester.Source.Token);
 
+                tester.Logger.LogResult(result, RequestType.CreateTimeSeries, false);
+
                 Assert.Single(result.Results);
                 Assert.Equal(4, result.Errors.Count());
                 Assert.Equal($"{tester.Prefix} final-ts-ok", result.Results.First().ExternalId);


### PR DESCRIPTION
I found that a thorough method to log the results of a request could be useful. This prints a summary, and optionally also the contents of each error. This is just so that users do not have to implement their own version