### PR TITLE
Metrics: Pass a create function to the Prometheus client

### DIFF
--- a/Cognite.Config/Cognite.Configuration.csproj
+++ b/Cognite.Config/Cognite.Configuration.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="YamlDotNet" Version="9.1.4" />
+    <PackageReference Include="YamlDotNet" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -8,11 +8,11 @@
     <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CogniteSdk" Version="1.5.0-beta-003" />
+    <PackageReference Include="CogniteSdk" Version="1.5.0" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Oryx" Version="3.0.0-beta-004" />
+    <PackageReference Include="Oryx" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/ExtractorUtils/ExtractorUtils.csproj
+++ b/ExtractorUtils/ExtractorUtils.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.27.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.28.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cognite.Config\Cognite.Configuration.csproj" />


### PR DESCRIPTION
In some instances, the requests to the push gateway keep timing out (such as DNS changes). This code passes the http client factory create function to the metrics pusher. The factory manages the lifetime of client and message handlers. Hopefully refreshing the clients may solve the problem.