### PR TITLE
Task scheduler

### DIFF
--- a/Cognite.Common/BlockingResourceCounter.cs
+++ b/Cognite.Common/BlockingResourceCounter.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Extractor.Common
+{
+    /// <summary>
+    /// Interface for generic common resource counter, which allows instant freeing, and asynchronous taking.
+    /// </summary>
+    public interface IResourceCounter
+    {
+        /// <summary>
+        /// Take <paramref name="count"/> instances of the resource.
+        /// Returns at least 1, if there are zero instances available, blocks until there are.
+        /// </summary>
+        /// <param name="count">Maximum number to take</param>
+        /// <returns>The number of resources granted. At least 1, but no more than <paramref name="count"/></returns>
+        Task<int> Take(int count);
+        /// <summary>
+        /// Releases <paramref name="count"/> resources.
+        /// Behavior is not defined if this number was not taken before.
+        /// </summary>
+        /// <param name="count">Number of resources to free.</param>
+        void Free(int count);
+    }
+
+
+
+    /// <summary>
+    /// Simple construct to count number of available instances of some shared resource.
+    /// </summary>
+    public class BlockingResourceCounter : IResourceCounter
+    {
+        /// <summary>
+        /// Unsafe reference to the remaining resources.
+        /// Do not use this for thread safe logic.
+        /// </summary>
+        public int Count { get; private set; }
+
+        private readonly object _lock = new object();
+        /// <summary>
+        /// Resource counter constructor.
+        /// </summary>
+        /// <param name="initial">Number of resources initially available. Can safely be increased by calling Free</param>
+        public BlockingResourceCounter(int initial)
+        {
+            Count = initial;
+        }
+
+        /// <inheritdocs />
+        public Task<int> Take(int count)
+        {
+            return Task.Run(() =>
+            {
+                lock (_lock)
+                {
+                    while (Count == 0)
+                    {
+                        Monitor.Wait(_lock);
+                    }
+
+                    int toTake = Math.Min(Count, count);
+                    Count -= toTake;
+                    return toTake;
+                }
+            });
+        }
+
+        /// <inheritdocs />
+        public void Free(int count)
+        {
+            lock (_lock)
+            {
+                Count += count;
+                Monitor.Pulse(_lock);
+            }
+        }
+    }
+}

--- a/Cognite.Common/SharedResourceScheduler.cs
+++ b/Cognite.Common/SharedResourceScheduler.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Extractor.Common
+{
+    /// <summary>
+    /// Abstraction for handling some kind of recursive exploration.
+    /// Simply a small extension to <see cref="OperationScheduler{T}"/> that
+    /// uses an instance of a <see cref="IResourceCounter"/> for shared capacity.
+    /// </summary>
+    /// <typeparam name="T">Type of item to explore</typeparam>
+    public abstract class SharedResourceScheduler<T> : OperationScheduler<T>
+    {
+        private readonly IResourceCounter _resource;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="initialItems">List of initial items, must be non-empty</param>
+        /// <param name="throttler">TaskThrottler to use. Can be shared with other schedulers</param>
+        /// <param name="chunkSize">Maximum number of items per chunk</param>
+        /// <param name="resource">Shared resource to limit parallel requests based on</param>
+        /// <param name="token">Cancellation token</param>
+        public SharedResourceScheduler(
+            IEnumerable<T> initialItems,
+            TaskThrottler throttler,
+            int chunkSize,
+            IResourceCounter resource,
+            CancellationToken token)
+            : base(initialItems, throttler, chunkSize, token)
+        {
+            if (resource == null) throw new ArgumentNullException(nameof(resource));
+            _resource = resource;
+        }
+
+        /// <summary>
+        /// Get <paramref name="requested"/> capacity from the shared resource manager.
+        /// Returns a number between 1 and <paramref name="requested" />, blocks if
+        /// there are zero resources available unless <paramref name="shouldBlock"/> is false,
+        /// then returns immediately.
+        /// </summary>
+        /// <param name="requested">Amount of capacity to request</param>
+        /// <param name="shouldBlock">True if this should block</param>
+        /// <returns>The number of resources allocated</returns>
+        protected override Task<int> GetCapacity(int requested, bool shouldBlock)
+        {
+            return _resource.Take(requested, shouldBlock);
+        }
+
+        /// <summary>
+        /// Free <paramref name="freed"/> capacity from the shared resource manager.
+        /// </summary>
+        /// <param name="freed">Amount of capacity to free</param>
+        protected override void FreeCapacity(int freed)
+        {
+            _resource.Free(freed);
+        }
+    }
+}

--- a/Cognite.Common/TaskScheduler.cs
+++ b/Cognite.Common/TaskScheduler.cs
@@ -1,0 +1,343 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Extractor.Common
+{
+    /// <summary>
+    /// Interface representing a chunk of items in TaskScheduler
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IChunk<T>
+    {
+        /// <summary>
+        /// Items in chunk
+        /// </summary>
+        IEnumerable<T> Items { get; }
+        /// <summary>
+        /// Exception if chunk operation failed
+        /// </summary>
+        Exception Exception { get; set; }
+        /// <summary>
+        /// Return true if the passed item (which is a member of this chunk) is completed
+        /// </summary>
+        /// <param name="item">Item to verify</param>
+        /// <returns>True if T is complete and can be removed</returns>
+        bool Completed(T item);
+    }
+
+    /// <summary>
+    /// Abstraction for handling some kind of recursive exploration.
+    /// Option for shared, asynchronous limits, and using a shared TaskThrottler.
+    /// </summary>
+    /// <typeparam name="T">Type of item to explore</typeparam>
+    public abstract class TaskScheduler<T> : IDisposable
+    {
+        private IEnumerable<T> _activeItems;
+        private int _numPending;
+        private readonly TaskThrottler _throttler;
+        private readonly BlockingCollection<IChunk<T>> _finishedOps = new BlockingCollection<IChunk<T>>();
+        private readonly CancellationTokenSource _source;
+
+        private readonly int _chunkSize;
+
+        private int _numRuns;
+        private int _numFinished;
+        private int _numTotal;
+        private bool _disposed;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="initialItems">List of initial items, must be non-empty</param>
+        /// <param name="throttler">TaskThrottler to use. Can be shared with other schedulers</param>
+        /// <param name="chunkSize">Maximum number of items per chunk</param>
+        /// <param name="token">Cancellation token</param>
+        public TaskScheduler(IEnumerable<T> initialItems, TaskThrottler throttler, int chunkSize, CancellationToken token)
+        {
+            _activeItems = initialItems;
+            _throttler = throttler;
+            _numTotal = _activeItems.Count();
+            _chunkSize = chunkSize;
+            _source = CancellationTokenSource.CreateLinkedTokenSource(token);
+        }
+        #region abstract methods
+        /// <summary>
+        /// Request to start reading <paramref name="requested"/> nodes.
+        /// Must return a number greater than 0 and less than <paramref name="requested"/>.
+        /// May block if scheduler should wait for resources to be freed elsewhere.
+        /// </summary>
+        /// <param name="requested">Maximum to request</param>
+        /// <returns>Number greater than 0 and less than <paramref name="requested"/></returns>
+        protected abstract Task<int> GetCapacity(int requested);
+        /// <summary>
+        /// Return used capacity allocated using GetCapacity.
+        /// </summary>
+        /// <param name="freed">Amount of capacity to free</param>
+        protected abstract void FreeCapacity(int freed);
+
+        /// <summary>
+        /// Construct a chunk object from a list of items.
+        /// </summary>
+        /// <param name="items">Items to construct chunk from</param>
+        /// <returns></returns>
+        protected abstract IChunk<T> GetChunk(IEnumerable<T> items);
+
+        /// <summary>
+        /// Method being called from TaskThrottler, operate on chunk and store the result so that it
+        /// can be retrieved from the chunk later.
+        /// Can safely throw exceptions, they are stored and can be handled in HandleTaskResult later.
+        /// </summary>
+        /// <param name="chunk">Chunk to consume</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Task</returns>
+        protected abstract Task ConsumeChunk(IChunk<T> chunk, CancellationToken token);
+
+        /// <summary>
+        /// Handle the result of a chunk operation. Called from the main loop after completion is reported.
+        /// Returns a list of newly discovered items that should be scheduled.
+        /// </summary>
+        /// <param name="chunk">Chunk to handle</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>New elements</returns>
+        protected abstract IEnumerable<T> HandleTaskResult(IChunk<T> chunk, CancellationToken token);
+
+        /// <summary>
+        /// Called if the scheduler is aborted before it finishes running.
+        /// Handle any cleanup of resources related to the passed chunks.
+        /// FreeCapacity is called outside of this method.
+        /// </summary>
+        /// <param name="chunk">Chunk to free</param>
+        /// <param name="token">Cancellation token</param>
+        protected abstract void AbortChunk(IChunk<T> chunk, CancellationToken token);
+
+        /// <summary>
+        /// Called on each iteration of the scheduler loop, for reporting.
+        /// </summary>
+        /// <param name="pending">Number of items currently pending</param>
+        /// <param name="operations">Number of operations that have been completed thus far</param>
+        /// <param name="finished">Number of items that have been finished</param>
+        /// <param name="total">Number of items that have been discovered in total</param>
+        protected abstract void OnIteration(int pending, int operations, int finished, int total);
+        #endregion
+
+        /// <summary>
+        /// Get a single chunk from list.
+        /// Should not return more items than <paramref name="capacity"/>.
+        /// Default implementation chunks by chunkSize and capacity.
+        /// </summary>
+        /// <param name="items">Items to take from</param>
+        /// <param name="capacity">Maximum number to return</param>
+        /// <param name="newItems">New list after iterating. Can be a linq expression,
+        /// does not need to maintain the same order, but should ensure that started items
+        /// are placed first.</param>
+        /// <returns>Items in a single new chunk</returns>
+        protected virtual IEnumerable<T> GetNextChunk(IEnumerable<T> items, int capacity, out IEnumerable<T> newItems)
+        {
+            int toTake = _chunkSize > 0 ? Math.Min(capacity, _chunkSize) : capacity;
+            var chunk = items.Take(toTake);
+            newItems = items.Skip(toTake);
+            return chunk;
+        }
+
+        /// <summary>
+        /// Get next chunks by consuming items from list.
+        /// Should not get more items than <paramref name="capacity"/>
+        /// Default implementation simply calls GetNextChunk until it returns nothing or
+        /// remaining capacity is 0.
+        /// </summary>
+        /// <param name="items">Items to take from</param>
+        /// <param name="capacity">Maximum number to return</param>
+        /// <param name="newItems">New list after iterating. Can be a linq expression,
+        /// does not need to maintain the same order, but should ensure that started items
+        /// are placed first.</param>
+        /// <returns>List of new chunks.</returns>
+        protected virtual IEnumerable<IChunk<T>> GetNextChunks(IEnumerable<T> items, int capacity, out IEnumerable<T> newItems)
+        {
+            var chunks = new List<IChunk<T>>();
+            IEnumerable<T> chunk;
+            do
+            {
+                chunk = GetNextChunk(items, capacity, out items);
+                capacity -= chunk.Count();
+                if (chunk.Any())
+                {
+                    chunks.Add(GetChunk(chunk));
+                }
+            } while (chunk.Any() && items.Any() && capacity > 0);
+            newItems = items;
+            return chunks;
+        }
+
+        private async Task ConsumeChunkInternal(IChunk<T> chunk, CancellationToken token)
+        {
+            try
+            {
+                await ConsumeChunk(chunk, token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                chunk.Exception = ex;
+            }
+            _finishedOps.Add(chunk, token);
+        }
+
+        /// <summary>
+        /// Start the scheduler loop.
+        /// </summary>
+        /// <returns> Task which terminates when the scheduler is finished</returns>
+        public Task RunAsync()
+        {
+            return Task.Run(() => Run(), CancellationToken.None);
+        }
+
+
+
+        /// <summary>
+        /// Runs in a single thread, so that logic in the ThreadScheduler is thread safe.
+        /// </summary>
+        private void Run()
+        {
+            var capacity = GetCapacity(_activeItems.Count()).Result;
+            var chunks = GetNextChunks(_activeItems, 0, out _activeItems).ToList();
+            foreach (var chunk in chunks)
+            {
+                _numPending += chunk.Items.Count();
+            }
+
+            // Number of items in the pending list that have not been freed.
+            int numContinued = 0;
+
+            while ((_numPending > 0 || chunks.Any()) && !_source.Token.IsCancellationRequested)
+            {
+                var generators = chunks.Select<IChunk<T>, Func<Task>>(chunk => () => ConsumeChunkInternal(chunk, _source.Token));
+
+                foreach (var generator in generators)
+                {
+                    _throttler.EnqueueTask(generator);
+                }
+                chunks.Clear();
+
+                var finished = new List<IChunk<T>>();
+                try
+                {
+                    finished.Add(_finishedOps.Take(_source.Token));
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                while (_finishedOps.TryTake(out var chunk))
+                {
+                    finished.Add(chunk);
+                }
+
+                var toContinue = new List<T>();
+                var newItems = new List<T>();
+                foreach (var chunk in finished)
+                {
+                    int count = chunk.Items.Count();
+                    _numRuns += count;
+                    int numFinished = 0;
+                    foreach (var item in chunk.Items)
+                    {
+                        _numRuns++;
+                        var next = HandleTaskResult(chunk, _source.Token);
+                        foreach (var newItem in next)
+                        {
+                            newItems.Add(item);
+                            _numTotal++;
+                        }
+                        if (!chunk.Completed(item))
+                        {
+                            numContinued++;
+                            toContinue.Add(item);
+                        }
+                        else
+                        {
+                            numFinished++;
+                        }
+                    }
+                    // Free any finished items here
+                    _numPending -= numFinished;
+                    _numFinished += numFinished;
+                    FreeCapacity(numFinished);
+                }
+
+                OnIteration(_numPending, _numRuns, _numFinished, _numTotal);
+
+                // Call ToList regularly to not get into LINQ-overload.
+                _activeItems = toContinue.Concat(_activeItems).Concat(newItems).ToList();
+
+                // Do not request capacity for items which have not yet been freed.
+                int toRequest = _activeItems.Count() - numContinued;
+                if (toRequest > 0)
+                {
+                    capacity = GetCapacity(toRequest).Result;
+                }
+                else
+                {
+                    capacity = 0;
+                }
+
+                // We still have capacity for any that have not been freed.
+                var nextChunks = GetNextChunks(_activeItems, capacity + numContinued, out _activeItems);
+                foreach (var chunk in nextChunks)
+                {
+                    int count = chunk.Items.Count();
+                    if (numContinued > 0)
+                    {
+                        int contConsumed = Math.Min(numContinued, count);
+                        numContinued -= contConsumed;
+                        count -= contConsumed;
+                    }
+                    _numPending += count;
+
+                    chunks.Add(chunk);
+                }
+            }
+
+            if (chunks.Any())
+            {
+                foreach (var chunk in chunks)
+                {
+                    AbortChunk(chunk, _source.Token);
+                }
+            }
+            if (_numPending > 0)
+            {
+                FreeCapacity(_numPending);
+            }
+        }
+
+        /// <summary>
+        /// Dispose method.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _source.Cancel();
+                    _source.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/ExtractorUtils.Test/unit/SchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/SchedulerTest.cs
@@ -1,0 +1,166 @@
+﻿using Cognite.Extractor.Common;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ExtractorUtils.Test.Unit
+{
+    class SchedulerItem
+    {
+        public int NumRemaining { get; set; }
+        public int NumChildren { get; set; }
+        public int DepthRemaining { get; set; }
+        public int MaxRemaining { get; set; }
+        public int FoundChildren { get; set; }
+    }
+
+    class SchedulerChunk : IChunk<SchedulerItem>
+    {
+        public IEnumerable<SchedulerItem> Items { get; set; }
+
+        public Exception Exception { get; set; }
+
+        public bool Completed(SchedulerItem item)
+        {
+            return item.NumRemaining == 0;
+        }
+    }
+
+    class TestScheduler : OperationScheduler<SchedulerItem>
+    {
+        public int Aborted { get; private set; }
+        public int Capacity { get; set; }
+        public int Pending { get; set; }
+        public int Operations { get; set; }
+        public int Finished { get; set; }
+        public int Total { get; set; }
+        public int CountItems { get; set; }
+        public int CountChunks { get; set; }
+
+        public TestScheduler(
+            IEnumerable<SchedulerItem> initialItems,
+            int chunkSize,
+            TaskThrottler throttler,
+            CancellationToken token) : base(initialItems, throttler, chunkSize, token)
+        {
+
+        }
+
+
+        protected override void AbortChunk(IChunk<SchedulerItem> chunk, CancellationToken token)
+        {
+            Aborted++;
+        }
+
+        protected override async Task ConsumeChunk(IChunk<SchedulerItem> chunk, CancellationToken token)
+        {
+            await Task.Delay(10);
+        }
+
+        protected override void FreeCapacity(int freed)
+        {
+            Capacity += freed;
+        }
+
+        protected override Task<int> GetCapacity(int requested)
+        {
+            int toAlloc = Math.Min(Capacity, requested);
+            Capacity -= toAlloc;
+            return Task.FromResult(toAlloc);
+        }
+
+        protected override IChunk<SchedulerItem> GetChunk(IEnumerable<SchedulerItem> items)
+        {
+            return new SchedulerChunk
+            {
+                Items = items
+            };
+        }
+
+        protected override IEnumerable<SchedulerItem> HandleTaskResult(IChunk<SchedulerItem> chunk, CancellationToken token)
+        {
+            CountChunks++;
+            foreach (var item in chunk.Items)
+            {
+                item.NumRemaining--;
+                if (item.DepthRemaining > 0)
+                {
+                    for (int i = 0; i < item.NumChildren; i++)
+                    {
+                        item.FoundChildren++;
+                        CountItems++;
+                        yield return new SchedulerItem
+                        {
+                            DepthRemaining = item.DepthRemaining - 1,
+                            NumChildren = item.NumChildren,
+                            NumRemaining = item.MaxRemaining,
+                            MaxRemaining = item.MaxRemaining
+                        };
+                    }
+                }
+            }
+        }
+
+        protected override void OnIteration(int pending, int operations, int finished, int total)
+        {
+            Pending = pending;
+            Operations = operations;
+            Finished = finished;
+            Total = total;
+        }
+    }
+
+    public class SchedulerTest
+    {
+        [Fact]
+        public async Task TestScheduler()
+        {
+            using var throttler = new TaskThrottler(2);
+            var items = new[]
+            {
+                // 6 children with 6 children each = 1 + 6 + 6 * 6 = 43
+                new SchedulerItem
+                {
+                    DepthRemaining = 2,
+                    NumChildren = 2,
+                    NumRemaining = 3,
+                    MaxRemaining = 3
+                },
+                // Just 1 item
+                new SchedulerItem
+                {
+                    DepthRemaining = 0,
+                    NumChildren = 2,
+                    NumRemaining = 1,
+                    MaxRemaining = 1
+                },
+                // 2 children three times = 1 + 2 + 2 * 2 + 2 * 2 * 2 = 15
+                new SchedulerItem
+                {
+                    DepthRemaining = 3,
+                    NumChildren = 1,
+                    NumRemaining = 2,
+                    MaxRemaining = 2
+                }
+            };
+
+            int totalItems = 43 + 1 + 15;
+            int totalReads = 43 * 3 + 1 + 15 * 2;
+
+            using var scheduler = new TestScheduler(items, 3, throttler, CancellationToken.None);
+            scheduler.Capacity = 6;
+
+            await scheduler.RunAsync();
+
+            Assert.True(scheduler.CountChunks >= totalReads / 3);
+            Assert.Equal(0, scheduler.Pending);
+            Assert.Equal(6, scheduler.Capacity);
+            Assert.Equal(totalReads, scheduler.Operations);
+            Assert.Equal(totalItems, scheduler.CountItems + 3);
+            Assert.Equal(totalItems, scheduler.Total);
+            Assert.Equal(totalItems, scheduler.Finished);
+        }
+    }
+}


### PR DESCRIPTION
A fairly abstract construct that I nonetheless ended up needing several times in the OPC-UA extractor and decided to add here, as part of an effort to reduce code duplication in OPC-UA. If it doesn't fit I can just add it to the extractor instead, but I think it is sufficiently general that it doesn't hurt to keep it here.

The idea is that it's a sort of producer-consumer scheduler, where a generic list of items are consumed. Each item may need to be run several times, and may produce a new list of child items to consume.

An example of this is exploring a hierarchy, but also reading history (in that case no new nodes are discovered, but this is still a useful construct).

In addition, it contains a system to share capacity. In OPC-UA this is a system of continuation points, but it could also be a cross-source throttler if history involves reading from multiple sources.

This is intended as a very generic base class, it might be helpful to add other base classes later, to handle more specific cases.