### PR TITLE
Base extractor class

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,16 +24,6 @@ jobs:
     - name: Unit Test
       run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ --filter ExtractorUtils.Test.Unit. ./ExtractorUtils.Test/
       if: ${{ github.event == 'pull_request' && github.base_ref == 'refs/heads/integration' }}
-      env:
-        TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
-        TEST_PROJECT: "extractor-tests"
-        TEST_HOST: "https://greenfield.cognitedata.com"
-        BF_TEST_PROJECT: "extractor-bluefield-testing"
-        BF_TEST_HOST: "https://bluefield.cognitedata.com"
-        BF_TEST_SCOPE: "https://bluefield.cognitedata.com/.default"
-        BF_TEST_CLIENT_ID: ${{ secrets.BF_TEST_CLIENT_ID }}
-        BF_TEST_TENANT: ${{ secrets.BF_TEST_TENANT }}
-        BF_TEST_SECRET: ${{ secrets.BF_TEST_SECRET }}
     - name: Test
       run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ ./ExtractorUtils.Test/
       if: ${{ github.event != 'pull_request' || github.base_ref == 'refs/heads/master' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,16 @@ jobs:
     - name: Unit Test
       run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ --filter ExtractorUtils.Test.Unit. ./ExtractorUtils.Test/
       if: ${{ github.event == 'pull_request' && github.base_ref == 'refs/heads/integration' }}
+      env:
+        TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
+        TEST_PROJECT: "extractor-tests"
+        TEST_HOST: "https://greenfield.cognitedata.com"
+        BF_TEST_PROJECT: "extractor-bluefield-testing"
+        BF_TEST_HOST: "https://bluefield.cognitedata.com"
+        BF_TEST_SCOPE: "https://bluefield.cognitedata.com/.default"
+        BF_TEST_CLIENT_ID: ${{ secrets.BF_TEST_CLIENT_ID }}
+        BF_TEST_TENANT: ${{ secrets.BF_TEST_TENANT }}
+        BF_TEST_SECRET: ${{ secrets.BF_TEST_SECRET }}
     - name: Test
       run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ ./ExtractorUtils.Test/
       if: ${{ github.event != 'pull_request' || github.base_ref == 'refs/heads/master' }}

--- a/Cognite.Common/PeriodicScheduler.cs
+++ b/Cognite.Common/PeriodicScheduler.cs
@@ -67,6 +67,7 @@ namespace Cognite.Extractor.Common
                 var task = new PeriodicTask(operation, interval, name);
                 task.Task = Task.Run(async () => await RunPeriodicTask(task).ConfigureAwait(false));
                 _tasks[name] = task;
+                _newTaskEvent.Set();
             }
         }
 
@@ -85,6 +86,7 @@ namespace Cognite.Extractor.Common
                 var task = new PeriodicTask(operation, TimeSpan.Zero, name);
                 task.Task = Task.Run(async () => await operation(_source.Token).ConfigureAwait(false));
                 _tasks[name] = task;
+                _newTaskEvent.Set();
             }
         }
 
@@ -117,7 +119,7 @@ namespace Cognite.Extractor.Common
             PeriodicTask task;
             lock (_taskListMutex)
             {
-                if (!_tasks.TryGetValue(name, out task)) throw new InvalidOperationException($"No such task: {name}");
+                if (!_tasks.TryGetValue(name, out task)) return;
             }
 
             await task.Task.ConfigureAwait(false);

--- a/Cognite.Common/PeriodicScheduler.cs
+++ b/Cognite.Common/PeriodicScheduler.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Extractor.Common
+{
+    internal sealed class PeriodicTask : IDisposable
+    {
+        public Task Task { get; set; }
+        public Func<CancellationToken, Task> Operation { get; }
+        public ManualResetEvent Event { get; } = new ManualResetEvent(false);
+        public TimeSpan Interval { get; }
+        public bool Paused { get; set; }
+        public bool ShouldRun { get; set; } = true;
+        public PeriodicTask(Func<CancellationToken, Task> operation, TimeSpan interval)
+        {
+            Operation = operation;
+        }
+        public void Dispose()
+        {
+            Event.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Utility to schedule and manage periodic tasks
+    /// </summary>
+    public class PeriodicScheduler : IDisposable
+    {
+        private CancellationTokenSource _source;
+        private Dictionary<string, PeriodicTask> _tasks = new Dictionary<string, PeriodicTask>();
+        private bool disposedValue;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="token">Cancellation token linked to all running tasks</param>
+        public PeriodicScheduler(CancellationToken token)
+        {
+            _source = CancellationTokenSource.CreateLinkedTokenSource(token);
+        }
+
+        /// <summary>
+        /// Schedule a new periodic task to run with interval <paramref name="interval"/>.
+        /// Exceptions are not caught, so <paramref name="operation"/> should catch its own errors.
+        /// </summary>
+        /// <param name="name">Name of task, used to refer to it later</param>
+        /// <param name="interval">Interval to schedule on</param>
+        /// <param name="operation">Function to call on each iteration</param>
+        public void SchedulePeriodicTask(string name, TimeSpan interval, Func<CancellationToken, Task> operation)
+        {
+            if (_tasks.ContainsKey(name)) throw new InvalidOperationException($"A task with name {name} already exists");
+            var task = new PeriodicTask(operation, interval);
+            task.Task = RunPeriodicTask(task);
+            _tasks[name] = task;
+        }
+
+        /// <summary>
+        /// Signal a task should terminate then wait. This will not cancel the operation if it is running,
+        /// but wait for it to terminate.
+        /// Will throw an exception if the task has failed.
+        /// </summary>
+        /// <param name="name">Name of task to cancel</param>
+        /// <returns>Task which completes once the task has terminated</returns>
+        public async Task ExitAndWaitForTermination(string name)
+        {
+            if (!_tasks.TryGetValue(name, out var task)) throw new InvalidOperationException($"No such task: {name}");
+            task.ShouldRun = false;
+            task.Event.Set();
+            await task.Task.ConfigureAwait(false);
+            _tasks.Remove(name);
+        }
+
+        /// <summary>
+        /// Same as calling ExitAndWaitForTermination on all tasks.
+        /// </summary>
+        /// <returns>Task which completes once all tasks are done</returns>
+        public async Task ExitAllAndWait()
+        {
+            var tasks = new List<Task>(_tasks.Count);
+            foreach (var task in _tasks.Values)
+            {
+                task.ShouldRun = false;
+                task.Event.Set();
+                tasks.Add(task.Task);
+            }
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            _tasks.Clear();
+        }
+
+        /// <summary>
+        /// Set the paused state of the named task. In this state it will only trigger
+        /// when manually triggered. Same as setting the timespan to infinite when creating the task.
+        /// </summary>
+        /// <param name="name">Name of task to pause</param>
+        /// <param name="paused">True to pause the task, false to unpause</param>
+        public void PauseTask(string name, bool paused)
+        {
+            if (!_tasks.TryGetValue(name, out var task)) throw new InvalidOperationException($"No such task: {name}");
+            task.Paused = paused;
+        }
+        /// <summary>
+        /// Manually trigger a task. The task will always run after this, but may run twice if it is about to run due to timeout.
+        /// Either way the task will always run after this.  
+        /// </summary>
+        /// <param name="name"></param>
+        public void TriggerTask(string name)
+        {
+            if (!_tasks.TryGetValue(name, out var task)) throw new InvalidOperationException($"No such task: {name}");
+            task.Event.Set();
+        }
+
+        private async Task RunPeriodicTask(PeriodicTask task)
+        {
+            while (!_source.IsCancellationRequested && task.ShouldRun)
+            {
+                var timeout = task.Paused ? Timeout.InfiniteTimeSpan : task.Interval;
+                var waitTask = WaitAsync(task.Event, task.Interval, _source.Token);
+                if (!task.Paused) await task.Operation(_source.Token).ConfigureAwait(false);
+                await waitTask.ConfigureAwait(false);
+                task.Event.Reset();
+            }
+        }
+
+
+
+        /// <summary>
+        /// Convenient method to efficiently wait for a wait handle and cancellation token with timeout
+        /// asynchronously. From https://thomaslevesque.com/2015/06/04/async-and-cancellation-support-for-wait-handles/.
+        /// </summary>
+        /// <param name="handle">WaitHandle to wait for</param>
+        /// <param name="timeout">Wait timeout</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>True if wait handle or cancellation token was triggered, false otherwise</returns>
+        private static async Task<bool> WaitAsync(WaitHandle handle, TimeSpan timeout, CancellationToken token)
+        {
+            RegisteredWaitHandle registeredHandle = null;
+            CancellationTokenRegistration tokenRegistration = default(CancellationTokenRegistration);
+            try
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                registeredHandle = ThreadPool.RegisterWaitForSingleObject(
+                    handle,
+                    (state, timedOut) => ((TaskCompletionSource<bool>)state).TrySetResult(!timedOut),
+                    tcs,
+                    timeout,
+                    true);
+                tokenRegistration = token.Register(
+                    state => ((TaskCompletionSource<bool>)state).TrySetCanceled(),
+                    tcs);
+                return await tcs.Task.ConfigureAwait(true);
+            }
+            finally
+            {
+                if (registeredHandle != null)
+                    registeredHandle.Unregister(null);
+                tokenRegistration.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Dispose of scheduler. Will cancel all running tasks.
+        /// Override this in subclasses.
+        /// </summary>
+        /// <param name="disposing">True to dispose</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _source.Cancel();
+                    _source.Dispose();
+                    foreach (var kvp in _tasks) kvp.Value.Dispose();
+                    _tasks.Clear();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Dispose of scheduler. Will cancel all running tasks.
+        /// Do not override this in subclasses.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -192,6 +192,15 @@ namespace Cognite.Extractor.Configuration
         public static void AddConfig<T>(this IServiceCollection services, T config, params Type[] types)
         {
             if (!types.Any()) return;
+            foreach (var type in types)
+            {
+                if (type.IsAssignableFrom(typeof(T)))
+                {
+                    services.AddSingleton(typeof(T), config);
+                    break;
+                }
+            }
+
             foreach (var prop in typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public))
             {
                 if (!prop.CanRead) continue;

--- a/ExampleExtractor/ExampleExtractor.csproj
+++ b/ExampleExtractor/ExampleExtractor.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ExtractorUtils\ExtractorUtils.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Cognite.Extractor.Utils;
+using CogniteSdk;
+using System.Threading.Tasks;
+using System.Threading;
+using Cognite.Extensions;
+using System;
+using System.Collections.Generic;
+
+class MyExtractor : BaseExtractor
+{
+    public MyExtractor(BaseConfig config, CogniteDestination destination, CancellationToken token)
+        : base(config, destination, token)
+    {
+    }
+
+    public override async Task Start()
+    {
+        await Destination.EnsureTimeSeriesExistsAsync(new[]
+        {
+            new TimeSeriesCreate {
+                ExternalId = "sine-wave",
+                Name = "Sine Wave"
+            }
+        }, RetryMode.OnError, SanitationMode.Clean, Source.Token);
+        CreateTimeseriesQueue(1000, TimeSpan.FromSeconds(1), null);
+        ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
+        {
+            var dp = (
+                Identity.Create("sine-wave"),
+                new Datapoint(DateTime.UtcNow, Math.Sin(DateTime.UtcNow.Ticks))
+            );
+            return Task.FromResult<IEnumerable<(Identity, Datapoint)>>(new[] { dp });
+        });
+        // So that the extractor doesn't terminate immediately
+        await Scheduler.WaitForAll();
+    }
+}
+
+// Then, in the Main() method:
+class Program
+{
+    static void Main()
+    {
+        ExtractorRunner.Run<BaseConfig>(
+            "config.yml",
+            new[] { 1 },
+            "my-extractor",
+            "myextractor/1.0.0",
+            false,
+            true,
+            true,
+            true,
+            (provider, token) => new MyExtractor(
+                provider.GetRequiredService<BaseConfig>(),
+                provider.GetRequiredService<CogniteDestination>(),
+                token
+            ),
+            CancellationToken.None).Wait();
+    }
+}

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -9,12 +9,12 @@ using System.Collections.Generic;
 
 class MyExtractor : BaseExtractor
 {
-    public MyExtractor(BaseConfig config, CogniteDestination destination, CancellationToken token)
-        : base(config, destination, token)
+    public MyExtractor(BaseConfig config, CogniteDestination destination)
+        : base(config, destination)
     {
     }
 
-    public override async Task Start()
+    protected override async Task Start()
     {
         await Destination.EnsureTimeSeriesExistsAsync(new[]
         {
@@ -32,8 +32,6 @@ class MyExtractor : BaseExtractor
             );
             return Task.FromResult<IEnumerable<(Identity, Datapoint)>>(new[] { dp });
         });
-        // So that the extractor doesn't terminate immediately
-        await Scheduler.WaitForAll();
     }
 }
 
@@ -42,7 +40,7 @@ class Program
 {
     static void Main()
     {
-        ExtractorRunner.Run<BaseConfig>(
+        ExtractorRunner.Run<BaseConfig, MyExtractor>(
             "config.yml",
             new[] { 1 },
             "my-extractor",
@@ -51,11 +49,6 @@ class Program
             true,
             true,
             true,
-            (provider, token) => new MyExtractor(
-                provider.GetRequiredService<BaseConfig>(),
-                provider.GetRequiredService<CogniteDestination>(),
-                token
-            ),
             CancellationToken.None).Wait();
     }
 }

--- a/ExampleExtractor/config.yml
+++ b/ExampleExtractor/config.yml
@@ -1,0 +1,13 @@
+version: 1
+logger:
+  console:
+    level: verbose
+cognite:
+  project: ${BF_TEST_PROJECT}
+  host: ${BF_TEST_HOST}
+  idp-authentication:
+    client-id: ${BF_TEST_CLIENT_ID}
+    tenant: ${BF_TEST_TENANT}
+    secret: ${BF_TEST_SECRET}
+    scopes:
+      - ${BF_TEST_SCOPE}

--- a/ExtractorUtils.Test/integration/ExtractorTest.cs
+++ b/ExtractorUtils.Test/integration/ExtractorTest.cs
@@ -1,7 +1,5 @@
 ﻿using Cognite.Extensions;
-using Cognite.Extractor.Common;
 using Cognite.Extractor.Utils;
-using Cognite.ExtractorUtils;
 using CogniteSdk;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -119,14 +117,14 @@ namespace ExtractorUtils.Test.Integration
                 true,
                 false,
                 false,
-                provider =>
+                (provider, token) =>
                 {
                     destination = provider.GetRequiredService<CogniteDestination>();
                     extractor = new TestExtractor(
                         prefix,
                         provider.GetRequiredService<BaseConfig>(),
                         destination,
-                        source.Token);
+                        token);
                     return extractor;
                 },
                 source.Token);

--- a/ExtractorUtils.Test/integration/ExtractorTest.cs
+++ b/ExtractorUtils.Test/integration/ExtractorTest.cs
@@ -1,4 +1,5 @@
 ﻿using Cognite.Extensions;
+using Cognite.Extractor.Common;
 using Cognite.Extractor.Utils;
 using Cognite.ExtractorUtils;
 using CogniteSdk;

--- a/ExtractorUtils.Test/integration/ExtractorTest.cs
+++ b/ExtractorUtils.Test/integration/ExtractorTest.cs
@@ -1,0 +1,217 @@
+﻿using Cognite.Extensions;
+using Cognite.Extractor.Utils;
+using Cognite.ExtractorUtils;
+using CogniteSdk;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ExtractorUtils.Test.Integration
+{
+    class TestRawItem
+    {
+        public string Field { get; set; }
+    }
+
+    class TestExtractor : BaseExtractor
+    {
+        public string TSId { get; private set; }
+        public List<string> CreatedEvents { get; private set; }
+        public string DBName { get; private set; }
+        public string TableName { get; private set; }
+        private string _prefix;
+        public TestExtractor(string prefix, BaseConfig config, CogniteDestination destination, CancellationToken token) 
+            : base(config, destination, token)
+        {
+            _prefix = prefix;
+        }
+
+
+        public override async Task Start()
+        {
+            DBName = $"{_prefix}-test-db";
+            TableName = $"{_prefix}-test-table";
+            CreateEventQueue(10, TimeSpan.FromSeconds(1), null);
+            CreateTimeseriesQueue(10, TimeSpan.FromSeconds(1), null);
+            CreateRawQueue<TestRawItem>(DBName, TableName, 
+                10, TimeSpan.FromSeconds(1), null);
+
+            TSId = $"{_prefix}-test-db";
+
+            await Destination.EnsureTimeSeriesExistsAsync(new[]
+            {
+                new TimeSeriesCreate
+                {
+                    ExternalId = TSId,
+                    Name = "BaseExtractor test TS",
+                    IsString = false
+                }
+            }, RetryMode.OnError, SanitationMode.Clean, Source.Token);
+
+            await Destination.CogniteClient.Raw.CreateTablesAsync(DBName, new[]
+            {
+                new RawTable { Name = TableName }
+            }, true);
+
+            int counter = 0;
+            int evtCounter = 0;
+
+            CreatedEvents = new List<string>();
+
+            ScheduleRawRun("raw", DBName, TableName, TimeSpan.FromMilliseconds(100), token =>
+            {
+                var row = ($"row-{counter}", new TestRawItem { Field = $"field-{counter}" });
+                counter++;
+                return Task.FromResult<IEnumerable<(string, TestRawItem)>>(new[] { row });
+            });
+
+            ScheduleEventsRun("events", TimeSpan.FromMilliseconds(100), token =>
+            {
+                var evt = new EventCreate
+                {
+                    ExternalId = $"{_prefix}-event-{evtCounter++}"
+                };
+                CreatedEvents.Add(evt.ExternalId);
+                return Task.FromResult<IEnumerable<EventCreate>>(new[] { evt });
+            });
+
+            ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
+            {
+                var dp = (Identity.Create(TSId), new Datapoint(DateTime.UtcNow, Math.Sin(DateTime.UtcNow.Ticks)));
+                return Task.FromResult<IEnumerable<(Identity, Datapoint)>>(new [] { dp });
+            });
+
+            await Scheduler.WaitForAll();
+        }
+    }
+
+
+    public class ExtractorTest
+    {
+        [Fact]
+        public async Task TestExtractorRun()
+        {
+            var configPath = "test-config-base-extractor";
+            var config = CDFTester.GetConfig(CogniteHost.BlueField);
+            System.IO.File.WriteAllLines(configPath, config);
+
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            Random random = new Random();
+            var prefix = "net-utils-test-" + new string(Enumerable.Repeat(chars, 5)
+              .Select(s => s[random.Next(s.Length)]).ToArray());
+
+            using var source = new CancellationTokenSource();
+
+            TestExtractor extractor = null;
+            CogniteDestination destination = null;
+
+            var task = ExtractorRunner.Run<BaseConfig>(
+                configPath,
+                null,
+                "base-extractor-test-utils",
+                null,
+                false,
+                true,
+                false,
+                false,
+                provider =>
+                {
+                    destination = provider.GetRequiredService<CogniteDestination>();
+                    extractor = new TestExtractor(
+                        prefix,
+                        provider.GetRequiredService<BaseConfig>(),
+                        destination,
+                        source.Token);
+                    return extractor;
+                },
+                source.Token);
+
+            try
+            {
+                bool eventsOk = true;
+                bool timeseriesOk = true;
+                bool rawOk = true;
+                for (int i = 0; i < 10; i++)
+                {
+                    eventsOk = true;
+                    timeseriesOk = true;
+                    rawOk = true;
+
+                    if (extractor?.CreatedEvents?.Count >= 10)
+                    {
+                        var evts = new List<string>();
+                        for (int j = 0; j < 10; j++) evts.Add(extractor.CreatedEvents[j]);
+                        var events = await destination.CogniteClient.Events.RetrieveAsync(evts, true);
+                        if (events.Count() != 10) eventsOk = false;
+
+                        var dps = await destination.CogniteClient.DataPoints.ListAsync(new DataPointsQuery
+                        {
+                            Items = new[]
+                            {
+                            new DataPointsQueryItem
+                            {
+                                ExternalId = extractor.TSId
+                            }
+                        }
+                        });
+
+                        if (dps.Items.First().NumericDatapoints.Datapoints.Count < 10) timeseriesOk = false;
+
+                        var rows = await destination.CogniteClient.Raw.ListRowsAsync(extractor.DBName, extractor.TableName);
+                        if (rows.Items.Count() < 10) rawOk = false;
+                    }
+                    else
+                    {
+                        eventsOk = timeseriesOk = rawOk = false;
+                    }
+                    if (eventsOk && timeseriesOk && rawOk) break;
+
+                    await Task.Delay(1000);
+                }
+
+                Assert.True(eventsOk && timeseriesOk && rawOk, $"{eventsOk}, {rawOk}, {timeseriesOk}");
+
+               
+            }
+            finally
+            {
+                source.Cancel();
+                await Task.WhenAny(task, Task.Delay(10000));
+
+                System.IO.File.Delete(configPath);
+
+                await destination.CogniteClient.Raw.DeleteDatabasesAsync(new RawDatabaseDelete
+                {
+                    Items = new[]
+                    {
+                        new RawDatabase { Name = extractor.DBName }
+                    },
+                    Recursive = true
+                });
+                await destination.CogniteClient.TimeSeries.DeleteAsync(new TimeSeriesDelete
+                {
+                    IgnoreUnknownIds = true,
+                    Items = new[]
+                    {
+                        Identity.Create(extractor.TSId)
+                    }
+                });
+                if (extractor.CreatedEvents.Any())
+                {
+                    await destination.CogniteClient.Events.DeleteAsync(new EventDelete
+                    {
+                        Items = extractor.CreatedEvents.Select(Identity.Create),
+                        IgnoreUnknownIds = true
+                    });
+                }
+
+                Assert.True(task.IsCompleted);
+            }
+            
+        }
+    }
+}

--- a/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
@@ -260,7 +260,6 @@ namespace ExtractorUtils.Test.Integration
         }
 
         [Theory]
-        [InlineData(CogniteHost.GreenField)]
         [InlineData(CogniteHost.BlueField)]
         public async Task TestUploadQueue(CogniteHost host)
         {
@@ -321,8 +320,6 @@ namespace ExtractorUtils.Test.Integration
                     var queryItem = new DataPointsQueryItem()
                     {
                         ExternalId = ts.ExternalId,
-                        Start = $"{startTime.ToUnixTimeMilliseconds()}",
-                        End = $"{DateTime.UtcNow.ToUnixTimeMilliseconds() + 1}",
                         Limit = 100
                     };
                     query.Add(queryItem);

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -265,11 +265,27 @@ namespace ExtractorUtils.Test.Unit
                 singleRuns++;
                 return Task.CompletedTask;
             });
-            Assert.Throws<InvalidOperationException>(() => scheduler.ScheduleTask("periodic", null));
+
+            // Schedule interally looping task
+            bool shouldLoop = true;
+            scheduler.ScheduleTask("intLoop", async token =>
+            {
+                while (shouldLoop)
+                {
+                    await Task.Delay(100);
+                }
+            });
+            Assert.Throws<InvalidOperationException>(() => scheduler.ScheduleTask("intLoop", null));
 
             // Wait for single to terminate
             await scheduler.WaitForTermination("single");
             Assert.Equal(1, singleRuns);
+
+            // Wait for internally looping to terminate
+            var intTask = scheduler.WaitForTermination("intLoop");
+            shouldLoop = false;
+            await intTask;
+
 
             // pause periodic
             await Task.Delay(500);

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -242,5 +242,53 @@ namespace ExtractorUtils.Test.Unit
             Assert.Equal(7, result.Aggregate(0, (seed, res) => seed + res.Count()));
             Assert.Equal(lengths, result.Select(res => res.Count()));
         }
+        [Fact]
+        public static async Task TestPeriodicScheduler()
+        {
+            using var source = new CancellationTokenSource();
+            using var scheduler = new PeriodicScheduler(source.Token);
+
+            int periodicRuns = 0;
+
+            // Schedule periodic
+            scheduler.SchedulePeriodicTask("periodic", TimeSpan.FromMilliseconds(100), token =>
+            {
+                periodicRuns++;
+                return Task.CompletedTask;
+            });
+            Assert.Throws<InvalidOperationException>(() => scheduler.SchedulePeriodicTask("periodic", TimeSpan.Zero, null));
+
+            int singleRuns = 0;
+            // Schedule single
+            scheduler.ScheduleTask("single", token =>
+            {
+                singleRuns++;
+                return Task.CompletedTask;
+            });
+            Assert.Throws<InvalidOperationException>(() => scheduler.ScheduleTask("periodic", null));
+
+            // Wait for single to terminate
+            await scheduler.WaitForTermination("single");
+            Assert.Equal(1, singleRuns);
+
+            // pause periodic
+            await Task.Delay(500);
+            Assert.True(periodicRuns > 1);
+            scheduler.PauseTask("periodic", true);
+            int numRuns = periodicRuns;
+            await Task.Delay(500);
+            // It might run once more, if it was already scheduled to run
+            Assert.True(periodicRuns <= numRuns + 1);
+
+
+            // Exit periodic and wait
+            await scheduler.ExitAndWaitForTermination("periodic");
+            source.Cancel();
+
+            var task = scheduler.WaitForAll();
+
+            await Task.WhenAll(task, Task.Delay(2000));
+            Assert.True(task.IsCompleted);
+        }
     }
 }

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Cognite.ExtractorUtils
+namespace Cognite.Extractor.Utils
 {
     /// <summary>
     /// Base class for extractors writing timeseries, events or datapoints.

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -1,0 +1,242 @@
+﻿using Cognite.Extensions;
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using CogniteSdk;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.ExtractorUtils
+{
+    /// <summary>
+    /// Base class for extractors writing timeseries, events or datapoints.
+    /// </summary>
+    public abstract class BaseExtractor : IDisposable
+    {
+        private bool disposedValue;
+
+        /// <summary>
+        /// Configuration object
+        /// </summary>
+        protected BaseConfig Config { get; }
+        /// <summary>
+        /// CDF destination
+        /// </summary>
+        protected CogniteDestination Destination { get; }
+        /// <summary>
+        /// Timeseries upload queue
+        /// </summary>
+        protected TimeSeriesUploadQueue TSUploadQueue { get; private set; }
+        /// <summary>
+        /// Event upload queue
+        /// </summary>
+        protected EventUploadQueue EventUploadQueue { get; private set; }
+        /// <summary>
+        /// Raw upload queues, by dbName-tableName and type.
+        /// </summary>
+        protected Dictionary<(string name, Type type), IUploadQueue> RawUploadQueues { get; private set; }
+            = new Dictionary<(string name, Type type), IUploadQueue>();
+        /// <summary>
+        /// Scheduler for running various periodic tasks
+        /// </summary>
+        protected PeriodicScheduler Scheduler { get; }
+        /// <summary>
+        /// Cancellation token source
+        /// </summary>
+        protected CancellationTokenSource Source { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="config">Configuration object</param>
+        /// <param name="destination">Cognite destination</param>
+        /// <param name="token">Cancellation token</param>
+        public BaseExtractor(BaseConfig config, CogniteDestination destination, CancellationToken token)
+        {
+            Config = config;
+            Destination = destination;
+            Source = CancellationTokenSource.CreateLinkedTokenSource(token);
+            Scheduler = new PeriodicScheduler(Source.Token);
+        }
+
+        /// <summary>
+        /// Create a raw queue with the given type and name
+        /// </summary>
+        /// <typeparam name="T">Type of columns in raw queue</typeparam>
+        /// <param name="dbName">Name of database in Raw</param>
+        /// <param name="tableName">Name of table in Raw</param>
+        /// <param name="maxSize">Max size of queue before triggering push, 0 for no limit</param>
+        /// <param name="uploadInterval">Interval between each push to CDF</param>
+        /// <param name="callback">Callback after each push</param>
+        protected void CreateRawQueue<T>(
+            string dbName,
+            string tableName,
+            int maxSize,
+            TimeSpan uploadInterval,
+            Func<QueueUploadResult<(string key, T columns)>, Task> callback)
+        {
+            string name = $"{dbName}-{tableName}";
+            if (RawUploadQueues.ContainsKey(($"{name}", typeof(T))))
+                throw new InvalidOperationException($"Upload queue with type {typeof(T)}" +
+                    $" and name {name} already exists");
+            var queue = Destination.CreateRawUploadQueue(
+                dbName,
+                tableName,
+                uploadInterval,
+                maxSize,
+                callback);
+            RawUploadQueues[($"{name}", typeof(T))] = queue;
+            _ = queue.Start(Source.Token);
+        }
+
+        /// <summary>
+        /// Schedule a periodic run with the given type and name.
+        /// Requires a raw queue with matching type and db/table to be created first.
+        /// </summary>
+        /// <typeparam name="T">Type of columns</typeparam>
+        /// <param name="scheduleName">Name of schedule in Scheduler, must be unique</param>
+        /// <param name="dbName">Database in Raw</param>
+        /// <param name="tableName">Table in Raw</param>
+        /// <param name="readInterval">Interval between each execution of <paramref name="readRawRows"/></param>
+        /// <param name="readRawRows">Function asynchronously returning a new batch of raw rows from the source system</param>
+        protected void ScheduleRawRun<T>(
+            string scheduleName,
+            string dbName,
+            string tableName,
+            TimeSpan readInterval,
+            Func<CancellationToken, Task<IEnumerable<(string key, T columns)>>> readRawRows)
+        {
+            string name = $"{dbName}-{tableName}";
+            if (!RawUploadQueues.TryGetValue((name, typeof(T)), out var queue))
+                throw new InvalidOperationException($"Upload queue with type {typeof(T)} and name {name} has not been created");
+
+            var rawQueue = (RawUploadQueue<T>)queue;
+
+            Scheduler.SchedulePeriodicTask(scheduleName, readInterval, async (token) =>
+            {
+                var rows = await readRawRows(token).ConfigureAwait(false);
+                rawQueue.Enqueue(rows);
+            });
+        }
+
+        /// <summary>
+        /// Set the TSUploadQueue value to a new timeseries queue.
+        /// </summary>
+        /// <param name="maxSize">Maximum size of queue before pushing to CDF, 0 for no limit</param>
+        /// <param name="uploadInterval">Interval between each push to CDF</param>
+        /// <param name="callback">Callback after each push to CDF</param>
+        /// <param name="bufferPath">Optional path to buffer file</param>
+        protected void CreateTimeseriesQueue(
+            int maxSize,
+            TimeSpan uploadInterval,
+            Func<QueueUploadResult<(Identity id, Datapoint dp)>, Task> callback,
+            string bufferPath = null)
+        {
+            if (TSUploadQueue != null) throw new InvalidOperationException("Timeseries upload queue already created");
+            TSUploadQueue = Destination.CreateTimeSeriesUploadQueue(
+                uploadInterval,
+                maxSize,
+                callback,
+                bufferPath);
+            _ = TSUploadQueue.Start(Source.Token);
+        }
+
+        /// <summary>
+        /// Schedule a periodic run retrieving datapoints from source systems.
+        /// </summary>
+        /// <param name="scheduleName">Name of task in Scheduler, must be unique</param>
+        /// <param name="readInterval">Interval between each read</param>
+        /// <param name="readDatapoints">Function reading datapoints from the source system</param>
+        protected void ScheduleDatapointsRun(
+            string scheduleName,
+            TimeSpan readInterval,
+            Func<CancellationToken, Task<IEnumerable<(Identity id, Datapoint dp)>>> readDatapoints)
+        {
+            if (TSUploadQueue == null) throw new InvalidOperationException("Timeseries queue has not been created");
+            Scheduler.SchedulePeriodicTask(scheduleName, readInterval, async (token) =>
+            {
+                var dps = await readDatapoints(token).ConfigureAwait(false);
+                TSUploadQueue.Enqueue(dps);
+            });
+        }
+
+        /// <summary>
+        /// Set the EventUploadQueue value to a new event queue.
+        /// </summary>
+        /// <param name="maxSize">Maximum size of queue before pushing to CDF, 0 for no limit</param>
+        /// <param name="uploadInterval">Interval between each push to CDF</param>
+        /// <param name="callback">Callback after each push to CDF</param>
+        /// <param name="bufferPath">Optional path to buffer file</param>
+        protected void CreateEventQueue(
+            int maxSize,
+            TimeSpan uploadInterval,
+            Func<QueueUploadResult<EventCreate>, Task> callback,
+            string bufferPath = null)
+        {
+            if (EventUploadQueue != null) throw new InvalidOperationException("Event upload queue already created");
+            EventUploadQueue = Destination.CreateEventUploadQueue(
+                uploadInterval,
+                maxSize,
+                callback,
+                bufferPath);
+            _ = EventUploadQueue.Start(Source.Token);
+        }
+
+        /// <summary>
+        /// Schedule a periodic run retrieving events from source systems.
+        /// </summary>
+        /// <param name="scheduleName">Name of task in Scheduler, must be unique</param>
+        /// <param name="readInterval">Interval between each read</param>
+        /// <param name="readEvents">Function reading events from the source system</param>
+        protected void ScheduleEventsRun(
+            string scheduleName,
+            TimeSpan readInterval,
+            Func<CancellationToken, Task<IEnumerable<EventCreate>>> readEvents)
+        {
+            if (EventUploadQueue == null) throw new InvalidOperationException("Event queue has not been created");
+            Scheduler.SchedulePeriodicTask(scheduleName, readInterval, async (token) =>
+            {
+                var events = await readEvents(token).ConfigureAwait(false);
+                EventUploadQueue.Enqueue(events);
+            });
+        }
+
+        /// <summary>
+        /// Dispose of extractor, waiting for running tasks and pushing everything pending to CDF.
+        /// </summary>
+        /// <param name="disposing">True if disposing</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Scheduler.ExitAllAndWait().Wait();
+                    Scheduler.Dispose();
+                    EventUploadQueue?.Dispose();
+                    TSUploadQueue?.Dispose();
+                    foreach (var queue in RawUploadQueues.Values)
+                    {
+                        queue.Dispose();
+                    }
+                    RawUploadQueues.Clear();
+                    Source.Cancel();
+                    Source.Dispose();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Dispose extractor.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -61,6 +61,21 @@ namespace Cognite.ExtractorUtils
         }
 
         /// <summary>
+        /// Verify that the extractor is configured correctly.
+        /// </summary>
+        /// <returns>Task</returns>
+        public virtual async Task TestConfig()
+        {
+            await Destination.TestCogniteConfig(Source.Token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Method called to start the extractor.
+        /// </summary>
+        /// <returns></returns>
+        public abstract Task Start();
+
+        /// <summary>
         /// Create a raw queue with the given type and name
         /// </summary>
         /// <typeparam name="T">Type of columns in raw queue</typeparam>

--- a/ExtractorUtils/Cognite/CogniteDestination.cs
+++ b/ExtractorUtils/Cognite/CogniteDestination.cs
@@ -422,7 +422,7 @@ namespace Cognite.Extractor.Utils
         /// Creates a Raw upload queue. It can be used to queue DTOs (data type objects) of type <typeparamref name="T"/>
         /// before sending them to CDF Raw. The items are dequeued and uploaded every <paramref name="interval"/>. If <paramref name="maxQueueSize"/> is
         /// greater than zero, the queue will have a maximum size, and items are also uploaded as soon as the maximum size is reached.
-        /// To start the upload loop, use the <see cref="IRawUploadQueue{T}.Start(CancellationToken)"/> method. To stop it, dispose of the queue or
+        /// To start the upload loop, use the <see cref="IUploadQueue.Start(CancellationToken)"/> method. To stop it, dispose of the queue or
         /// cancel the token
         /// </summary>
         /// <param name="database">Raw database name</param>

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -1,0 +1,121 @@
+﻿using Cognite.Extractor.Configuration;
+using Cognite.Extractor.Metrics;
+using Cognite.Extractor.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.ExtractorUtils
+{
+    /// <summary>
+    /// Contains utilities for running an extractor based on BaseExtractor
+    /// </summary>
+    public static class ExtractorRunner
+    {
+        /// <summary>
+        /// Configure and run an extractor with config of type <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">Type of configuration</typeparam>
+        /// <param name="configPath">Path to yml config file</param>
+        /// <param name="acceptedConfigVersions">List of accepted config versions, null accepts all</param>
+        /// <param name="appId">AppId to append to requests to CDF</param>
+        /// <param name="userAgent">User agent on form Product/Version</param>
+        /// <param name="addStateStore">True if the extractor uses a state store</param>
+        /// <param name="addLogger">True to add logging</param>
+        /// <param name="addMetrics">True to add metrics</param>
+        /// <param name="restart">True to restart extractor if it crashes or terminates, using exponential backoff</param>
+        /// <param name="builder">Method constructing a new extractor using the service provider</param>
+        /// <param name="token">Optional cancellation token from external cancellation source</param>
+        /// <param name="services">Optional pre-configured service collection</param>
+        /// <returns>Task which completes when the extractor has run</returns>
+        public static async Task Run<T>(
+            string configPath,
+            int[] acceptedConfigVersions,
+            string appId,
+            string userAgent,
+            bool addStateStore,
+            bool addLogger,
+            bool addMetrics,
+            bool restart,
+            Func<IServiceProvider, BaseExtractor> builder,
+            CancellationToken token,
+            ServiceCollection services = null)
+            where T : VersionedConfig
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+            int waitRepeats = 1;
+
+            if (services == null) services = new ServiceCollection();
+            using (var source = CancellationTokenSource.CreateLinkedTokenSource(token))
+            {
+                Console.CancelKeyPress += (sender, eArgs) =>
+                {
+                    eArgs.Cancel = true;
+                    source?.Cancel();
+                };
+                while (!source.IsCancellationRequested)
+                {
+                    services.AddExtractorDependencies<T>(configPath, acceptedConfigVersions,
+                        appId, userAgent, addStateStore, addLogger, addMetrics);
+                    var provider = services.BuildServiceProvider();
+                    if (addMetrics)
+                    {
+                        var metrics = provider.GetRequiredService<MetricsService>();
+                    }
+                    ILogger<BaseExtractor> log = new NullLogger<BaseExtractor>();
+                    if (addLogger)
+                    {
+                        log = provider.GetRequiredService<ILogger<BaseExtractor>>();
+                    }
+                    var extractor = builder(provider);
+                    DateTime startTime = DateTime.UtcNow;
+                    try
+                    {
+                        await extractor.Start().ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException) when (source.IsCancellationRequested)
+                    {
+                        log.LogWarning("Extractor stopped manually");
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogError(ex, "Extractor crashed unexpectedly");
+                    }
+
+
+                    if (source.IsCancellationRequested || !restart) break;
+
+                    if (startTime > DateTime.UtcNow - TimeSpan.FromSeconds(600))
+                    {
+                        waitRepeats++;
+                    }
+                    else
+                    {
+                        waitRepeats = 1;
+                    }
+
+                    try
+                    {
+                        var sleepTime = TimeSpan.FromSeconds(Math.Pow(2, Math.Min(waitRepeats, 9)));
+                        log.LogInformation("Sleeping for {time}", sleepTime);
+                        Task.Delay(sleepTime, source.Token).Wait();
+                    }
+                    catch (Exception)
+                    {
+                        log.LogWarning("Extractor stopped manually");
+                        break;
+                    }
+                }
+            }
+         
+        }
+
+
+    }
+}

--- a/ExtractorUtils/queues/BaseUploadQueue.cs
+++ b/ExtractorUtils/queues/BaseUploadQueue.cs
@@ -31,6 +31,11 @@ namespace Cognite.Extractor.Utils
         /// <param name="item">Item to enqueue</param>
         void Enqueue(T item);
         /// <summary>
+        /// Enqueue a list of items in the internal queue.
+        /// </summary>
+        /// <param name="items">Items to enqueue</param>
+        void Enqueue(IEnumerable<T> items);
+        /// <summary>
         /// Empty the queue and return the contents
         /// </summary>
         /// <returns>Contents of the queue</returns>
@@ -138,6 +143,20 @@ namespace Cognite.Extractor.Utils
         public virtual void Enqueue(T item)
         {
             _items.Enqueue(item);
+            if (_maxSize > 0 && _items.Count >= _maxSize)
+            {
+                _pushEvent.Set();
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Enqueue(IEnumerable<T> items)
+        {
+            if (items == null) return;
+            foreach (var item in items)
+            {
+                _items.Enqueue(item);
+            }
             if (_maxSize > 0 && _items.Count >= _maxSize)
             {
                 _pushEvent.Set();

--- a/ExtractorUtils/queues/RawUploadQueue.cs
+++ b/ExtractorUtils/queues/RawUploadQueue.cs
@@ -28,15 +28,6 @@ namespace Cognite.Extractor.Utils
         /// <param name="key">The row key</param>
         /// <param name="columns">The row columns</param>
         void EnqueueRow(string key, T columns);
-
-        /// <summary>
-        /// Starts a <see cref="Task"/> to insert rows into CDF Raw at regular intervals. Waiting on the returned 
-        /// task will throw any eventual exceptions. To stop the upload queue, dispose the upload queue object or
-        /// cancel the provided <paramref name="token"/>.
-        /// </summary>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>Upload queue task</returns>
-        Task Start(CancellationToken token);
     }
     class RawUploadQueue<T> : BaseUploadQueue<(string key, T columns)>, IRawUploadQueue<T>
     {

--- a/ExtractorUtils/queues/RawUploadQueue.cs
+++ b/ExtractorUtils/queues/RawUploadQueue.cs
@@ -13,14 +13,8 @@ namespace Cognite.Extractor.Utils
     /// DTOs (data type objects) of type <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface IRawUploadQueue<T> : IDisposable
+    public interface IRawUploadQueue<T> : IDisposable, IUploadQueue<(string key, T columns)>
     {
-        /// <summary>
-        /// Trigger upload immediately, returning upload result
-        /// </summary>
-        /// <param name="token"></param>
-        /// <returns>Wrapper containing the list of columns or an error if upload failed</returns>
-        Task<QueueUploadResult<(string key, T columns)>> Trigger(CancellationToken token);
         /// <summary>
         /// Enqueue the DTO of type <typeparamref name="T"/> to be uploaded
         /// as a row to CDF Raw.

--- a/README.md
+++ b/README.md
@@ -54,48 +54,67 @@ See the [example configuration](ExtractorUtils/config/config.example.yml) for a 
 
 Set the ```COGNITE_PROJECT``` and ```COGNITE_API_KEY``` environment variables. Set the ```metrics``` tag, only if collecting metrics is required by the extractor. If using a [Prometheus pushgateway](https://prometheus.io/docs/practices/pushing/), set ```host```to a valid endpoint.
 
-The easiest way to use the library utilities is through **dependency injection**. Open ```Program.cs``` and use the library as follows:
+The easiest way to use the library utilities is by using the ```BaseExtractor``` class. The following is a working implementation of an extractor writing a sine wave to CDF.
 
 ```c#
 using Microsoft.Extensions.DependencyInjection;
-using Cognite.Extractor.Configuration;
-using Cognite.Extractor.Logging;
-using Cognite.Extractor.Metrics;
 using Cognite.Extractor.Utils;
+using Cognite.Extensions;
+using CogniteSdk;
+
+class MyExtractor : BaseExtractor
+{
+	public MyExtractor(BaseConfig config, CogniteDestination destination, CancellationToken token)
+		: base(config, destination, token)
+	{
+	}
+	
+	public override async Task Start() 
+	{
+		await Destination.EnsureTimeSeriesExistsAsync(new[]
+        {
+            new TimeSeriesCreate {
+                ExternalId = "sine-wave",
+                Name = "Sine Wave"
+            }
+        }, RetryMode.OnError, SanitationMode.Clean, Source.Token);
+		CreateTimeseriesQueue(1000, TimeSpan.FromSeconds(1), null);
+		ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
+		{
+			var dp = (
+				Identity.Create("sine-wave"),
+				new Datapoint(DateTime.UtcNow, Math.Sin(DateTime.UtcNow.Ticks))
+			);
+			return Task.FromResult<IEnumerable<(Identity, Datapoint)>>(new [] { dp });
+		});
+		// So that the extractor doesn't terminate immediately
+		await Scheduler.WaitForAll();
+	}
+}
 
 // Then, in the Main() method:
-var services = new ServiceCollection();
-services.AddConfig<BaseConfig>("./config.yml", 1);
-services.AddLogger();
-services.AddMetrics();
-services.AddCogniteClient("MyExtractor", true, true);
-
-// Create a service provider and resolve the required services
-using (var provider = services.BuildServiceProvider()) {
-    // Resolve a logger for this class
-    var logger = provider.GetRequiredService<ILogger<Program>>();
-    logger.LogInformation("Hello Extractor");
-
-    // Resolve the metrics service and start it
-    var metrics = provider.GetRequiredService<MetricsService>();
-    metrics.Start();
-    
-    // Resolve the cognite destination
-    var destination = provider.GetRequiredService<CogniteDestination>();
-    await destination.TestCogniteConfig(cancellationToken);
-    
-    // Use the Cognite destination to create time series and insert data points.
-    // For instance: The line below gets or create the time series. The buildTimeSeriesObjects is a callback function that creates
-    // TimeSeriesCreate objects for any missing time series.
-    var ts = await destination.GetOrCreateTimeSeriesAsync(
-        externalIds,
-        buildTimeSeriesObjects,
-        cancellationToken
-    );
-    
-    // Stops the metrics service
-    await metrics.Stop();
+class Program
+{
+	static void Main()
+	{
+		ExtractorRunner.Run<BaseConfig>(
+			"config.yml",
+			new[] { 1 },
+			"my-extractor",
+			"myextractor/1.0.0",
+			false,
+			true,
+			true,
+			true,
+			(provider, token) => new MyExtractor(
+				provider.GetRequiredService<BaseConfig>(),
+				provider.GetRequiredService<CogniteDestination>(),
+				token
+			),
+			CancellationToken.None).Wait();
+	}
 }
+
 ```
 
 ## Inserting data points:

--- a/README.md
+++ b/README.md
@@ -64,55 +64,50 @@ using CogniteSdk;
 
 class MyExtractor : BaseExtractor
 {
-	public MyExtractor(BaseConfig config, CogniteDestination destination, CancellationToken token)
-		: base(config, destination, token)
-	{
-	}
-	
-	public override async Task Start() 
-	{
-		await Destination.EnsureTimeSeriesExistsAsync(new[]
+    public MyExtractor(BaseConfig config, CogniteDestination destination, CancellationToken token)
+        : base(config, destination, token)
+    {
+    }
+    
+    public override async Task Start() 
+    {
+        await Destination.EnsureTimeSeriesExistsAsync(new[]
         {
             new TimeSeriesCreate {
                 ExternalId = "sine-wave",
                 Name = "Sine Wave"
             }
         }, RetryMode.OnError, SanitationMode.Clean, Source.Token);
-		CreateTimeseriesQueue(1000, TimeSpan.FromSeconds(1), null);
-		ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
-		{
-			var dp = (
-				Identity.Create("sine-wave"),
-				new Datapoint(DateTime.UtcNow, Math.Sin(DateTime.UtcNow.Ticks))
-			);
-			return Task.FromResult<IEnumerable<(Identity, Datapoint)>>(new [] { dp });
-		});
-		// So that the extractor doesn't terminate immediately
-		await Scheduler.WaitForAll();
-	}
+        CreateTimeseriesQueue(1000, TimeSpan.FromSeconds(1), null);
+        ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
+        {
+            var dp = (
+                Identity.Create("sine-wave"),
+                new Datapoint(DateTime.UtcNow, Math.Sin(DateTime.UtcNow.Ticks))
+            );
+            return Task.FromResult<IEnumerable<(Identity, Datapoint)>>(new [] { dp });
+        });
+        // So that the extractor doesn't terminate immediately
+        await Scheduler.WaitForAll();
+    }
 }
 
 // Then, in the Main() method:
 class Program
 {
-	static void Main()
-	{
-		ExtractorRunner.Run<BaseConfig>(
-			"config.yml",
-			new[] { 1 },
-			"my-extractor",
-			"myextractor/1.0.0",
-			false,
-			true,
-			true,
-			true,
-			(provider, token) => new MyExtractor(
-				provider.GetRequiredService<BaseConfig>(),
-				provider.GetRequiredService<CogniteDestination>(),
-				token
-			),
-			CancellationToken.None).Wait();
-	}
+    static void Main()
+    {
+        ExtractorRunner.Run<BaseConfig>(
+            "config.yml",
+            new[] { 1 },
+            "my-extractor",
+            "myextractor/1.0.0",
+            false,
+            true,
+            true,
+            true,
+            CancellationToken.None).Wait();
+    }
 }
 
 ```

--- a/dotnet-extractor-utils.sln
+++ b/dotnet-extractor-utils.sln
@@ -20,9 +20,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cognite.Metrics", "Cognite.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cognite.Common", "Cognite.Common\Cognite.Common.csproj", "{F08B268D-791D-4FFE-AA3E-3B5A7CA9F4FA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cognite.StateStorage", "Cognite.StateStorage\Cognite.StateStorage.csproj", "{86DA713B-2F4B-489A-95EA-C0BC1988EFF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cognite.StateStorage", "Cognite.StateStorage\Cognite.StateStorage.csproj", "{86DA713B-2F4B-489A-95EA-C0BC1988EFF1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cognite.Extensions", "Cognite.Extensions\Cognite.Extensions.csproj", "{8B5A5A21-C4D1-4547-85C9-AF2EABEE5832}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cognite.Extensions", "Cognite.Extensions\Cognite.Extensions.csproj", "{8B5A5A21-C4D1-4547-85C9-AF2EABEE5832}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleExtractor", "ExampleExtractor\ExampleExtractor.csproj", "{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -130,6 +132,18 @@ Global
 		{8B5A5A21-C4D1-4547-85C9-AF2EABEE5832}.Release|x64.Build.0 = Release|Any CPU
 		{8B5A5A21-C4D1-4547-85C9-AF2EABEE5832}.Release|x86.ActiveCfg = Release|Any CPU
 		{8B5A5A21-C4D1-4547-85C9-AF2EABEE5832}.Release|x86.Build.0 = Release|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Release|x64.Build.0 = Release|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{48FA47CD-E81B-4818-8AEC-D5B6CF834DA7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Base class for extractors, to minimize boilerplate code when creating simple extractors.

This is probably just the first step, for live data. Ideally it should also have features designed for history, and some way to enable state-store without too much boilerplate.

This PR also adds the `PeriodicScheduler` class, which simply runs tasks with a scheduled period, which can be interrupted externally. This is something more advanced extractors often end up needing, and it creates a very nice decentralized system for reading form source systems. In this case it is used heavily in the base extractor.

This PR adds a new main example to the README, and also adds that code to a separate (working) example project.