### PR TITLE
Refactor errors

### DIFF
--- a/Cognite.Extensions/Assets/AssetResultHandlers.cs
+++ b/Cognite.Extensions/Assets/AssetResultHandlers.cs
@@ -72,7 +72,7 @@ namespace Cognite.Extensions
         /// <returns>Assets that are not affected by the error</returns>
         public static async Task<IEnumerable<AssetCreate>> CleanFromError(
             AssetsResource resource,
-            CogniteError error,
+            CogniteError<AssetCreate> error,
             IEnumerable<AssetCreate> assets,
             int assetChunkSize,
             int assetThrottleSize,
@@ -103,7 +103,7 @@ namespace Cognite.Extensions
             var items = new HashSet<Identity>(error.Values);
 
             var ret = new List<AssetCreate>();
-            var skipped = new List<object>();
+            var skipped = new List<AssetCreate>();
 
             foreach (var asset in assets)
             {

--- a/Cognite.Extensions/Assets/AssetSanitation.cs
+++ b/Cognite.Extensions/Assets/AssetSanitation.cs
@@ -101,17 +101,17 @@ namespace Cognite.Extensions
         /// <param name="assets">AssetCreate request to clean</param>
         /// <param name="mode">The type of sanitation to apply</param>
         /// <returns>Cleaned create request and an optional error if any ids were duplicated</returns>
-        public static (IEnumerable<AssetCreate>, IEnumerable<CogniteError>) CleanAssetRequest(
+        public static (IEnumerable<AssetCreate>, IEnumerable<CogniteError<AssetCreate>>) CleanAssetRequest(
             IEnumerable<AssetCreate> assets,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (assets, Enumerable.Empty<CogniteError>());
+            if (mode == SanitationMode.None) return (assets, Enumerable.Empty<CogniteError<AssetCreate>>());
             if (assets == null)
             {
                 throw new ArgumentNullException(nameof(assets));
             }
             var result = new List<AssetCreate>();
-            var errors = new List<CogniteError>();
+            var errors = new List<CogniteError<AssetCreate>>();
 
             var ids = new HashSet<string>();
             var duplicated = new HashSet<string>();
@@ -154,7 +154,7 @@ namespace Cognite.Extensions
             }
             if (duplicated.Any())
             {
-                errors.Add(new CogniteError
+                errors.Add(new CogniteError<AssetCreate>
                 {
                     Status = 409,
                     Message = "Duplicate external ids",
@@ -165,7 +165,7 @@ namespace Cognite.Extensions
             }
             if (bad.Any())
             {
-                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError
+                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError<AssetCreate>
                 {
                     Skipped = group.Select(pair => pair.Item2).ToList(),
                     Resource = group.Key,

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -155,7 +155,9 @@ namespace Cognite.Extensions
             else if (other.Errors == null) errors = Errors;
             else errors = Errors.Concat(other.Errors);
 
-            return new CogniteResult<TError>(errors);
+            var result = new CogniteResult<TError>(errors);
+            result.MergeErrors();
+            return result;
         }
 
         /// <summary>
@@ -171,9 +173,9 @@ namespace Cognite.Extensions
                 if (result == null) continue;
                 if (result.Errors != null) errors.AddRange(result.Errors);
             }
-            var err = new CogniteResult<TError>(errors);
-            err.MergeErrors();
-            return err;
+            var res = new CogniteResult<TError>(errors);
+            res.MergeErrors();
+            return res;
         }
     }
 
@@ -220,9 +222,9 @@ namespace Cognite.Extensions
             else if (other.Errors == null) errors = Errors;
             else errors = Errors.Concat(other.Errors);
 
-            var err = new CogniteResult<TResult, TError>(errors, results);
-            err.MergeErrors();
-            return err;
+            var result = new CogniteResult<TResult, TError>(errors, results);
+            result.MergeErrors();
+            return result;
         }
 
         /// <summary>
@@ -241,9 +243,9 @@ namespace Cognite.Extensions
                 if (result.Errors != null) errors.AddRange(result.Errors);
             }
 
-            var err = new CogniteResult<TResult, TError>(errors, items);
-            err.MergeErrors();
-            return err;
+            var res = new CogniteResult<TResult, TError>(errors, items);
+            res.MergeErrors();
+            return res;
         }
     }
 
@@ -320,6 +322,9 @@ namespace Cognite.Extensions
                 if (err.Skipped != null) skipped.AddRange(err.Skipped);
                 if (err.Values != null) values.AddRange(err.Values);
             }
+
+            initial.Skipped = skipped;
+            initial.Values = values;
 
             return initial;
         }

--- a/Cognite.Extensions/Events/EventResultHandlers.cs
+++ b/Cognite.Extensions/Events/EventResultHandlers.cs
@@ -48,7 +48,7 @@ namespace Cognite.Extensions
         /// <param name="events">Events to clean</param>
         /// <returns>Events that are not affected by the error</returns>
         public static IEnumerable<EventCreate> CleanFromError(
-            CogniteError error,
+            CogniteError<EventCreate> error,
             IEnumerable<EventCreate> events)
         {
             if (events == null)
@@ -65,7 +65,7 @@ namespace Cognite.Extensions
             var items = new HashSet<Identity>(error.Values);
 
             var ret = new List<EventCreate>();
-            var skipped = new List<object>();
+            var skipped = new List<EventCreate>();
 
             foreach (var evt in events)
             {

--- a/Cognite.Extensions/Events/EventSanitation.cs
+++ b/Cognite.Extensions/Events/EventSanitation.cs
@@ -101,17 +101,17 @@ namespace Cognite.Extensions
         /// <param name="events">EventCreate request to clean</param>
         /// <param name="mode">The type of sanitation to apply</param>
         /// <returns>Cleaned request and optional error if any ids were duplicated</returns>
-        public static (IEnumerable<EventCreate>, IEnumerable<CogniteError>) CleanEventRequest(
+        public static (IEnumerable<EventCreate>, IEnumerable<CogniteError<EventCreate>>) CleanEventRequest(
             IEnumerable<EventCreate> events,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (events, Enumerable.Empty<CogniteError>());
+            if (mode == SanitationMode.None) return (events, Enumerable.Empty<CogniteError<EventCreate>>());
             if (events == null)
             {
                 throw new ArgumentNullException(nameof(events));
             }
             var result = new List<EventCreate>();
-            var errors = new List<CogniteError>();
+            var errors = new List<CogniteError<EventCreate>>();
 
             var ids = new HashSet<string>();
             var duplicated = new HashSet<string>();
@@ -149,7 +149,7 @@ namespace Cognite.Extensions
             }
             if (duplicated.Any())
             {
-                errors.Add(new CogniteError
+                errors.Add(new CogniteError<EventCreate>
                 {
                     Status = 409,
                     Message = "ExternalIds duplicated",
@@ -160,7 +160,7 @@ namespace Cognite.Extensions
             }
             if (bad.Any())
             {
-                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError
+                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError<EventCreate>
                 {
                     Skipped = group.Select(pair => pair.Item2).ToList(),
                     Resource = group.Key,

--- a/Cognite.Extensions/LoggerExtensions.cs
+++ b/Cognite.Extensions/LoggerExtensions.cs
@@ -22,8 +22,8 @@ namespace Cognite.Extensions
         /// <param name="ignoreExisting">True to not log errors caused by items already present in CDF</param>
         /// <param name="handledLevel">Log level of errors that were handled by the utils</param>
         /// <param name="fatalLevel">Log level of errors that could not be handled and caused the request to fail</param>
-        public static void LogCogniteError(this ILogger logger,
-            CogniteError error,
+        public static void LogCogniteError<TError>(this ILogger logger,
+            CogniteError<TError> error,
             RequestType requestType,
             bool ignoreExisting,
             LogLevel handledLevel = LogLevel.Debug,
@@ -84,8 +84,8 @@ namespace Cognite.Extensions
         }
 
 
-        private static void LogCommon<T>(ILogger logger,
-            CogniteResult<T> result,
+        private static void LogCommon<TResult, TError>(ILogger logger,
+            CogniteResult<TResult, TError> result,
             RequestType requestType,
             LogLevel infoLevel,
             LogLevel handledErrorLevel,
@@ -110,7 +110,8 @@ namespace Cognite.Extensions
         /// <summary>
         /// Log the CogniteResult object and all its errors.
         /// </summary>
-        /// <typeparam name="T">Type of result</typeparam>
+        /// <typeparam name="TResult">Type of result</typeparam>
+        /// <typeparam name="TError">Type of reported error</typeparam>
         /// <param name="logger">Logger to write to</param>
         /// <param name="result">Result to log</param>
         /// <param name="requestType">Request type</param>
@@ -118,8 +119,8 @@ namespace Cognite.Extensions
         /// <param name="infoLevel">Level for summary information about the request</param>
         /// <param name="handledErrorLevel">Log level of errors that were handled by the utils</param>
         /// <param name="fatalLevel">Log level of errors that could not be handled and caused the request to fail</param>
-        public static void LogResult<T>(this ILogger logger,
-            CogniteResult<T> result,
+        public static void LogResult<TResult, TError>(this ILogger logger,
+            CogniteResult<TResult, TError> result,
             RequestType requestType,
             bool ignoreExisting,
             LogLevel infoLevel = LogLevel.Information,

--- a/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
+++ b/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
@@ -327,7 +327,7 @@ namespace Cognite.Extensions
                     Status = 400,
                     Skipped = rowErrors,
                     Resource = ResourceType.SequenceRowValues,
-                    Type = ErrorType.SanitationFailed,
+                    Type = ErrorType.MismatchedType,
                     Values = rowErrors
                         .Where(seq => !createMap[seq.Id].Rows.Any())
                         .Select(seq => seq.Id)

--- a/Cognite.Extensions/TimeSeries/DataPointSanitation.cs
+++ b/Cognite.Extensions/TimeSeries/DataPointSanitation.cs
@@ -82,12 +82,12 @@ namespace Cognite.Extensions
         /// <param name="mode">Sanitation mode</param>
         /// <param name="nonFiniteReplacement">Optional replacement for non-finite values</param>
         /// <returns>Cleaned request and optional list of errors</returns>
-        public static (IDictionary<Identity, IEnumerable<Datapoint>>, IEnumerable<CogniteError>) CleanDataPointsRequest(
+        public static (IDictionary<Identity, IEnumerable<Datapoint>>, IEnumerable<CogniteError<DataPointInsertError>>) CleanDataPointsRequest(
             IDictionary<Identity, IEnumerable<Datapoint>> points,
             SanitationMode mode,
             double? nonFiniteReplacement)
         {
-            if (mode == SanitationMode.None) return (points, Enumerable.Empty<CogniteError>());
+            if (mode == SanitationMode.None) return (points, Enumerable.Empty<CogniteError<DataPointInsertError>>());
             if (points == null) throw new ArgumentNullException(nameof(points));
 
             var result = new Dictionary<Identity, IEnumerable<Datapoint>>();
@@ -137,14 +137,14 @@ namespace Cognite.Extensions
                 }
             }
 
-            IEnumerable<CogniteError> errors;
+            IEnumerable<CogniteError<DataPointInsertError>> errors;
 
             if (badDpGroups.Any())
             {
                 errors = badDpGroups
                     .GroupBy(group => group.type)
                     .Select(group =>
-                        new CogniteError
+                        new CogniteError<DataPointInsertError>
                         {
                             Status = 400,
                             Message = "Sanitation failed",
@@ -156,7 +156,7 @@ namespace Cognite.Extensions
             }
             else
             {
-                errors = Enumerable.Empty<CogniteError>();
+                errors = Enumerable.Empty<CogniteError<DataPointInsertError>>();
             }
 
             return (result, errors);

--- a/Cognite.Extensions/TimeSeries/TimeSeriesResultHandlers.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesResultHandlers.cs
@@ -62,7 +62,7 @@ namespace Cognite.Extensions
         /// <param name="timeseries">Timeseries to clean</param>
         /// <returns>TimeSeries that are not affected by the error</returns>
         public static IEnumerable<TimeSeriesCreate> CleanFromError(
-            CogniteError error,
+            CogniteError<TimeSeriesCreate> error,
             IEnumerable<TimeSeriesCreate> timeseries)
         {
             if (timeseries == null)
@@ -79,7 +79,7 @@ namespace Cognite.Extensions
             var items = new HashSet<Identity>(error.Values);
 
             var ret = new List<TimeSeriesCreate>();
-            var skipped = new List<object>();
+            var skipped = new List<TimeSeriesCreate>();
 
             foreach (var ts in timeseries)
             {

--- a/Cognite.Extensions/TimeSeries/TimeSeriesSanitation.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesSanitation.cs
@@ -88,17 +88,17 @@ namespace Cognite.Extensions
         /// <param name="timeseries">TimeSeriesCreate request to clean</param>
         /// <param name="mode">The type of sanitation to apply</param>
         /// <returns>Cleaned create request and optional errors for duplicated ids and legacyNames</returns>
-        public static (IEnumerable<TimeSeriesCreate>, IEnumerable<CogniteError>) CleanTimeSeriesRequest(
+        public static (IEnumerable<TimeSeriesCreate>, IEnumerable<CogniteError<TimeSeriesCreate>>) CleanTimeSeriesRequest(
             IEnumerable<TimeSeriesCreate> timeseries,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (timeseries, Enumerable.Empty<CogniteError>());
+            if (mode == SanitationMode.None) return (timeseries, Enumerable.Empty<CogniteError<TimeSeriesCreate>>());
             if (timeseries == null)
             {
                 throw new ArgumentNullException(nameof(timeseries));
             }
             var result = new List<TimeSeriesCreate>();
-            var errors = new List<CogniteError>();
+            var errors = new List<CogniteError<TimeSeriesCreate>>();
 
             var ids = new HashSet<string>();
             var duplicatedIds = new HashSet<string>();
@@ -148,7 +148,7 @@ namespace Cognite.Extensions
             }
             if (duplicatedIds.Any())
             {
-                errors.Add(new CogniteError
+                errors.Add(new CogniteError<TimeSeriesCreate>
                 {
                     Status = 409,
                     Message = "Conflicting identifiers",
@@ -159,7 +159,7 @@ namespace Cognite.Extensions
             }
             if (duplicatedNames.Any())
             {
-                errors.Add(new CogniteError
+                errors.Add(new CogniteError<TimeSeriesCreate>
                 {
                     Status = 409,
                     Message = "Duplicated metric names in request",
@@ -170,7 +170,7 @@ namespace Cognite.Extensions
             }
             if (bad.Any())
             {
-                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError
+                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError<TimeSeriesCreate>
                 {
                     Skipped = group.Select(pair => pair.Item2).ToList(),
                     Resource = group.Key,

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -16,13 +16,14 @@ class MyExtractor : BaseExtractor
 
     protected override async Task Start()
     {
-        await Destination.EnsureTimeSeriesExistsAsync(new[]
+        var result = await Destination.EnsureTimeSeriesExistsAsync(new[]
         {
             new TimeSeriesCreate {
                 ExternalId = "sine-wave",
                 Name = "Sine Wave"
             }
         }, RetryMode.OnError, SanitationMode.Clean, Source.Token);
+        result.Throw();
         CreateTimeseriesQueue(1000, TimeSpan.FromSeconds(1), null);
         ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
         {

--- a/ExtractorUtils.Test/integration/SequenceIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/SequenceIntegrationTest.cs
@@ -607,7 +607,8 @@ namespace ExtractorUtils.Test.Integration
 
                 Assert.Equal(ResourceType.SequenceRowValues, errs[3].Resource);
                 Assert.Equal(ErrorType.SanitationFailed, errs[3].Type);
-                Assert.Equal(5, errs[3].Skipped.Count());
+                Assert.Single(errs[3].Skipped);
+                Assert.Equal(5, errs[3].Skipped.First().SkippedRows.Count());
 
                 Assert.Equal(ResourceType.SequenceRowNumber, errs[4].Resource);
                 Assert.Equal(ErrorType.SanitationFailed, errs[4].Type);
@@ -637,7 +638,8 @@ namespace ExtractorUtils.Test.Integration
                 // Three of the bad rows have now been cleaned and should not be removed
                 Assert.Equal(ResourceType.SequenceRowValues, errs[4].Resource);
                 Assert.Equal(ErrorType.SanitationFailed, errs[4].Type);
-                Assert.Equal(2, errs[4].Skipped.Count());
+                Assert.Single(errs[4].Skipped);
+                Assert.Equal(2, errs[4].Skipped.First().SkippedRows.Count());
             }
             finally
             {
@@ -760,15 +762,13 @@ namespace ExtractorUtils.Test.Integration
                 Assert.Equal(ResourceType.ColumnExternalId, errs[1].Resource);
                 Assert.Equal(ErrorType.ItemMissing, errs[1].Type);
                 Assert.Single(errs[1].Skipped);
-                Assert.Single(errs[1].Data);
-                Assert.Equal(2, errs[1].Data.OfType<SequenceRowError>().Sum(err => err.BadRows.Count()));
-                Assert.Equal(2, errs[1].Data.OfType<SequenceRowError>().Sum(err => err.BadColumns.Count()));
+                Assert.Equal(2, errs[1].Skipped.Sum(err => err.SkippedRows.Count()));
 
                 Assert.Equal(ResourceType.SequenceRowValues, errs[2].Resource);
-                Assert.Equal(ErrorType.SanitationFailed, errs[2].Type);
-                Assert.Equal(5, errs[2].Skipped.Count());
+                Assert.Equal(ErrorType.MismatchedType, errs[2].Type);
+                Assert.Equal(2, errs[2].Skipped.Count());
+                Assert.Equal(5, errs[2].Skipped.Sum(err => err.SkippedRows.Count()));
                 Assert.Single(errs[2].Values);
-                Assert.Equal(2, errs[2].Data.Count());
             }
             finally
             {

--- a/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
@@ -579,34 +579,19 @@ namespace ExtractorUtils.Test.Integration
 
                 var errs = result.Errors.ToArray();
                 // Greenfield reports missing twice, once for each id type.
-                CogniteError err;
-                if (host == CogniteHost.BlueField)
-                {
-                    Assert.Equal(2, errs.Length);
-                    err = errs[0];
-                    Assert.Equal(ResourceType.Id, err.Resource);
-                    Assert.Equal(ErrorType.ItemMissing, err.Type);
-                    Assert.Equal(2, err.Values.Count());
-                    err = errs[1];
-                }
-                else
-                {
-                    Assert.Equal(3, errs.Length);
-                    err = errs[0];
-                    Assert.Equal(ResourceType.Id, err.Resource);
-                    Assert.Equal(ErrorType.ItemMissing, err.Type);
-                    Assert.Single(err.Values);
-                    err = errs[1];
-                    Assert.Equal(ResourceType.Id, err.Resource);
-                    Assert.Equal(ErrorType.ItemMissing, err.Type);
-                    Assert.Single(err.Values);
-                    err = errs[2];
-                }
+                CogniteError<DataPointInsertError> err;
+
+                Assert.Equal(2, errs.Length);
+                err = errs[0];
+                Assert.Equal(ResourceType.Id, err.Resource);
+                Assert.Equal(ErrorType.ItemMissing, err.Type);
+                Assert.Equal(2, err.Values.Count());
+                err = errs[1];
 
                 Assert.Equal(ResourceType.DataPointValue, err.Resource);
                 Assert.Equal(ErrorType.MismatchedType, err.Type);
                 Assert.Equal(3, err.Skipped.Count());
-                var insertErrs = err.Skipped.OfType<DataPointInsertError>().ToArray();
+                var insertErrs = err.Skipped.ToArray();
                 Assert.Equal(2, insertErrs[0].DataPoints.Count());
                 Assert.Equal(2, insertErrs[1].DataPoints.Count());
                 Assert.Equal(2, insertErrs[2].DataPoints.Count());

--- a/ExtractorUtils.Test/unit/CogniteResultTests.cs
+++ b/ExtractorUtils.Test/unit/CogniteResultTests.cs
@@ -29,7 +29,7 @@ namespace ExtractorUtils.Test.Unit
         public void ParseUnknownException()
         {
             var ex = new Exception("Some error");
-            var error = ResultHandlers.ParseException(ex, RequestType.CreateAssets);
+            var error = ResultHandlers.ParseException<AssetCreate>(ex, RequestType.CreateAssets);
             Assert.Equal(0, error.Status);
             Assert.Equal(ex, error.Exception);
             Assert.Equal("Some error", error.Message);
@@ -41,7 +41,7 @@ namespace ExtractorUtils.Test.Unit
             {
                 Code = 500
             };
-            var error = ResultHandlers.ParseException(ex, RequestType.CreateAssets);
+            var error = ResultHandlers.ParseException<AssetCreate>(ex, RequestType.CreateAssets);
             Assert.Equal(500, error.Status);
             Assert.Equal(ex, error.Exception);
             Assert.Equal("Something bad happened", error.Message);
@@ -106,7 +106,7 @@ namespace ExtractorUtils.Test.Unit
             var errors = new List<CogniteError>();
             for (int i = 0; i < exceptions.Length; i++)
             {
-                var error = ResultHandlers.ParseException(exceptions[i], RequestType.CreateAssets);
+                var error = ResultHandlers.ParseException<AssetCreate>(exceptions[i], RequestType.CreateAssets);
                 logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
                 assets = (await ResultHandlers.CleanFromError(null, error, assets, 1000, 1, CancellationToken.None))
                     .ToArray();
@@ -202,8 +202,8 @@ namespace ExtractorUtils.Test.Unit
             var errors = new List<CogniteError>();
             for (int i = 0; i < exceptions.Length; i++)
             {
-                var error = ResultHandlers.ParseException(exceptions[i], RequestType.CreateTimeSeries);
-                logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
+                var error = ResultHandlers.ParseException<TimeSeriesCreate>(exceptions[i], RequestType.CreateTimeSeries);
+                logger.LogCogniteError(error, RequestType.CreateTimeSeries, false, LogLevel.Debug, LogLevel.Warning);
                 timeseries = (ResultHandlers.CleanFromError(error, timeseries))
                     .ToArray();
                 Assert.Equal(9 - i * 2 - 2, timeseries.Count());
@@ -276,8 +276,8 @@ namespace ExtractorUtils.Test.Unit
             var errors = new List<CogniteError>();
             for (int i = 0; i < exceptions.Length; i++)
             {
-                var error = ResultHandlers.ParseException(exceptions[i], RequestType.CreateEvents);
-                logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
+                var error = ResultHandlers.ParseException<EventCreate>(exceptions[i], RequestType.CreateEvents);
+                logger.LogCogniteError(error, RequestType.CreateEvents, false, LogLevel.Debug, LogLevel.Warning);
                 events = (ResultHandlers.CleanFromError(error, events))
                     .ToArray();
                 Assert.Equal(7 - i * 2 - 2, events.Count());

--- a/ExtractorUtils.Test/unit/SanitationTest.cs
+++ b/ExtractorUtils.Test/unit/SanitationTest.cs
@@ -605,13 +605,13 @@ namespace ExtractorUtils.Test.Unit
             var (result, errors) = Sanitation.CleanSequenceRequest(sequences, SanitationMode.Clean);
             var errs = errors.ToList();
             Assert.Equal(4, result.Count());
-            Assert.Equal(4, errors.Count());
-            var err = errs[2];
+            Assert.Equal(3, errors.Count());
+            var err = errs[1];
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(ResourceType.ExternalId, err.Resource);
             Assert.Equal(2, err.Values.Count());
 
-            err = errs[3];
+            err = errs[2];
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Equal(ResourceType.SequenceColumns, err.Resource);
             Assert.Equal(2, err.Skipped.Count());
@@ -619,14 +619,7 @@ namespace ExtractorUtils.Test.Unit
             err = errs[0];
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(ResourceType.ColumnExternalId, err.Resource);
-            Assert.Single(err.Skipped);
-            Assert.Single(err.Values);
-
-            err = errs[1];
-            Assert.Equal(ErrorType.ItemDuplicated, err.Type);
-            Assert.Equal(ResourceType.ColumnExternalId, err.Resource);
-            Assert.Single(err.Skipped);
-            Assert.Single(err.Values);
+            Assert.Equal(2, err.Skipped.Count());
         }
         [Fact]
         public void TestSanitizeSequenceDataRequest()
@@ -684,18 +677,16 @@ namespace ExtractorUtils.Test.Unit
 
             var errs = errors.ToList();
             
-            var err = errs[0];
+            var err = errs[1];
             Assert.Equal(ResourceType.SequenceRowNumber, err.Resource);
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(409, err.Status);
-            Assert.Single(err.Values);
             Assert.Single(err.Skipped);
 
-            err = errs[1];
+            err = errs[0];
             Assert.Equal(ResourceType.ColumnExternalId, err.Resource);
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(409, err.Status);
-            Assert.Single(err.Values);
             Assert.Single(err.Skipped);
 
             err = errs[2];
@@ -718,13 +709,11 @@ namespace ExtractorUtils.Test.Unit
             Assert.Equal(ResourceType.SequenceRowValues, err.Resource);
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Equal(3, err.Skipped.Count());
-            Assert.Equal(3, err.Data.Count());
 
             err = errs[6];
             Assert.Equal(ResourceType.SequenceRowNumber, err.Resource);
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Single(err.Skipped);
-            Assert.Single(err.Data);
         }
         [Fact]
         public void SanitizeDataPointRequest()

--- a/ExtractorUtils/Cognite/CogniteDestination.cs
+++ b/ExtractorUtils/Cognite/CogniteDestination.cs
@@ -69,8 +69,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to timeseries before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occurred and a list of the created and found timeseries</returns>
-        public async Task<CogniteResult<TimeSeries>> GetOrCreateTimeSeriesAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occurred and a list of the created and found timeseries</returns>
+        public async Task<CogniteResult<TimeSeries, TimeSeriesCreate>> GetOrCreateTimeSeriesAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, IEnumerable<TimeSeriesCreate>> buildTimeSeries,
             RetryMode retryMode,
@@ -102,8 +102,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to timeseries before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found timeseries</returns>
-        public async Task<CogniteResult<TimeSeries>> GetOrCreateTimeSeriesAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found timeseries</returns>
+        public async Task<CogniteResult<TimeSeries, TimeSeriesCreate>> GetOrCreateTimeSeriesAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, Task<IEnumerable<TimeSeriesCreate>>> buildTimeSeries,
             RetryMode retryMode,
@@ -135,8 +135,8 @@ namespace Cognite.Extractor.Utils
         /// this method.</param>
         /// <param name="sanitationMode">The type of sanitation to apply to timeseries before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created timeseries</returns>
-        public async Task<CogniteResult<TimeSeries>> EnsureTimeSeriesExistsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created timeseries</returns>
+        public async Task<CogniteResult<TimeSeries, TimeSeriesCreate>> EnsureTimeSeriesExistsAsync(
             IEnumerable<TimeSeriesCreate> timeSeries,
             RetryMode retryMode,
             SanitationMode sanitationMode,
@@ -168,8 +168,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to assets before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found assets</returns>
-        public async Task<CogniteResult<Asset>> GetOrCreateAssetsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found assets</returns>
+        public async Task<CogniteResult<Asset, AssetCreate>> GetOrCreateAssetsAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, IEnumerable<AssetCreate>> buildAssets,
             RetryMode retryMode,
@@ -200,8 +200,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to assets before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found assets</returns>
-        public async Task<CogniteResult<Asset>> GetOrCreateAssetsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found assets</returns>
+        public async Task<CogniteResult<Asset, AssetCreate>> GetOrCreateAssetsAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, Task<IEnumerable<AssetCreate>>> buildAssets,
             RetryMode retryMode,
@@ -232,8 +232,8 @@ namespace Cognite.Extractor.Utils
         /// this method.</param>
         /// <param name="sanitationMode">The type of sanitation to apply to assets before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created assets</returns>
-        public async Task<CogniteResult<Asset>> EnsureAssetsExistsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created assets</returns>
+        public async Task<CogniteResult<Asset, AssetCreate>> EnsureAssetsExistsAsync(
             IEnumerable<AssetCreate> assets,
             RetryMode retryMode,
             SanitationMode sanitationMode,
@@ -263,7 +263,7 @@ namespace Cognite.Extractor.Utils
         /// <param name="sanitationMode"></param>
         /// <param name="retryMode"></param>
         /// <param name="token">Cancellation token</param>
-        public async Task<CogniteResult> InsertDataPointsAsync(
+        public async Task<CogniteResult<DataPointInsertError>> InsertDataPointsAsync(
             IDictionary<Identity, IEnumerable<Datapoint>> points,
             SanitationMode sanitationMode,
             RetryMode retryMode,
@@ -562,8 +562,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to events before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found events</returns>
-        public async Task<CogniteResult<Event>> GetOrCreateEventsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found events</returns>
+        public async Task<CogniteResult<Event, EventCreate>> GetOrCreateEventsAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, IEnumerable<EventCreate>> buildEvents,
             RetryMode retryMode,
@@ -594,8 +594,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to events before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found events</returns>
-        public async Task<CogniteResult<Event>> GetOrCreateEventsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found events</returns>
+        public async Task<CogniteResult<Event, EventCreate>> GetOrCreateEventsAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, Task<IEnumerable<EventCreate>>> buildEvents,
             RetryMode retryMode,
@@ -626,8 +626,8 @@ namespace Cognite.Extractor.Utils
         /// this method.</param>
         /// <param name="sanitationMode">The type of sanitation to apply to events before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created events</returns>
-        public async Task<CogniteResult<Event>> EnsureEventsExistsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created events</returns>
+        public async Task<CogniteResult<Event, EventCreate>> EnsureEventsExistsAsync(
             IEnumerable<EventCreate> events,
             RetryMode retryMode,
             SanitationMode sanitationMode,
@@ -659,8 +659,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to sequences before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found sequences</returns>
-        public async Task<CogniteResult<Sequence>> GetOrCreateSequencesAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found sequences</returns>
+        public async Task<CogniteResult<Sequence, SequenceCreate>> GetOrCreateSequencesAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, IEnumerable<SequenceCreate>> buildSequences,
             RetryMode retryMode,
@@ -691,8 +691,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="retryMode">How to handle failed requests</param>
         /// <param name="sanitationMode">The type of sanitation to apply to sequences before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created and found sequences</returns>
-        public async Task<CogniteResult<Sequence>> GetOrCreateSequencesAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found sequences</returns>
+        public async Task<CogniteResult<Sequence, SequenceCreate>> GetOrCreateSequencesAsync(
             IEnumerable<string> externalIds,
             Func<IEnumerable<string>, Task<IEnumerable<SequenceCreate>>> buildSequences,
             RetryMode retryMode,
@@ -723,8 +723,8 @@ namespace Cognite.Extractor.Utils
         /// this method.</param>
         /// <param name="sanitationMode">The type of sanitation to apply to sequences before creating</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured and a list of the created sequences</returns>
-        public async Task<CogniteResult<Sequence>> EnsureSequencesExistsAsync(
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created sequences</returns>
+        public async Task<CogniteResult<Sequence, SequenceCreate>> EnsureSequencesExistsAsync(
             IEnumerable<SequenceCreate> sequences,
             RetryMode retryMode,
             SanitationMode sanitationMode,
@@ -751,8 +751,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="sanitationMode">The type of sanitation to apply to sequences before creating.
         /// Errors that are normally handled by sanitation will not be handled if received from CDF.</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>A <see cref="CogniteResult"/> containing errors that occured during insertion</returns>
-        public async Task<CogniteResult> InsertSequenceRowsAsync(
+        /// <returns>A <see cref="CogniteResult{TError}"/> containing errors that occured during insertion</returns>
+        public async Task<CogniteResult<SequenceRowError>> InsertSequenceRowsAsync(
             IEnumerable<SequenceDataCreate> sequences,
             RetryMode retryMode,
             SanitationMode sanitationMode,


### PR DESCRIPTION
The original use of CogniteError and CogniteResult was just for assets/timeseries/events, and there it worked well enough. Now with more types, the use of `object` makes the system difficult to use. This PR changes that so that CogniteError now takes a type parameter, and also standardizing what an error represents.

This PR also fixes a few issues with logging, and adds a "ThrowOnError" method to CogniteResult so that errors can be translated back into exceptions.