### PR TITLE
Add option to automatically gzip datapoints

### DIFF
--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CogniteSdk" Version="1.6.4" />
+    <PackageReference Include="CogniteSdk" Version="1.6.5" />
     <PackageReference Include="prometheus-net" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />

--- a/ExtractorUtils/Cognite/CogniteDestination.cs
+++ b/ExtractorUtils/Cognite/CogniteDestination.cs
@@ -284,6 +284,7 @@ namespace Cognite.Extractor.Utils
                 _config.CdfThrottling.DataPoints,
                 _config.CdfChunking.TimeSeries,
                 _config.CdfThrottling.TimeSeries,
+                _config.CdfChunking.DataPointsGzipLimit,
                 sanitationMode,
                 retryMode,
                 _config.NanReplacement,

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -253,6 +253,11 @@ namespace Cognite.Extractor.Utils
         public int DataPoints { get; set; } = 100_000;
 
         /// <summary>
+        /// Minimum number of datapoints in a request before gzip should be used.
+        /// </summary>
+        public int DataPointsGzipLimit { get; set; } = 5_000;
+
+        /// <summary>
         /// Maximum number of rows per Raw row insert request
         /// </summary>
         /// <value>Maximum chunk size</value>

--- a/ExtractorUtils/config/config.example.yml
+++ b/ExtractorUtils/config/config.example.yml
@@ -58,6 +58,13 @@ cognite:
         data-point-time-series: 10000
         # Maximum number of datapoints per datapoint create request
         data-points: 100000
+        # Minimum number of datapoints in request to switch to using gzip.
+        # Set to -1 to disable, and 0 to always enable (not recommended)
+        # The minimum HTTP packet size is generally 1500 bytes, so this should never be
+        # set below 100, at least for numeric datapoints. Even for larger packages gzip is efficient enough
+        # that packages are compressed below 1500 bytes which is costly. At 5000 it is always a performance gain.
+        # It can be set lower if bandwith is a major issue.
+        data-points-gzip-limit: 5000
         # Maximum number of ranges per delete datapoints request
         data-point-delete: 10000
         # Maximum number of timeseries per datapoint read request, used when getting the first point in a timeseries


### PR DESCRIPTION
The default value and common in config.example.yml is based on some research done while writing this for the SDK. Turns out you need a fairly large number of datapoints before it is worthwhile. This feature counts the number of datapoints (not really the number of bytes, we could count lengths of all strings but I'm uncertain of how much that could cost), and decides on whether or not to use gzip based on a configurable limit.