### PR TITLE
Use IAsyncDisposable where relevant

### DIFF
--- a/ExtractorUtils.Test/integration/RawIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/RawIntegrationTest.cs
@@ -79,7 +79,7 @@ namespace ExtractorUtils.Test.Integration
 
             var totalUploaded = 0;
             try {
-                using (var queue = tester.Destination.CreateRawUploadQueue<TestDto>(dbName, tableName, TimeSpan.FromSeconds(1), 0, res => {
+                await using (var queue = tester.Destination.CreateRawUploadQueue<TestDto>(dbName, tableName, TimeSpan.FromSeconds(1), 0, res => {
                     var numUploaded = res.Uploaded?.Count() ?? 0;
                     totalUploaded += numUploaded;
                     tester.Logger.LogInformation("Sent {Num} raw rows to CDF", numUploaded);

--- a/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
@@ -288,7 +288,7 @@ namespace ExtractorUtils.Test.Integration
                 var result = await tester.Destination.EnsureTimeSeriesExistsAsync(timeseries, RetryMode.OnError, SanitationMode.Remove, tester.Source.Token);
                 tester.Logger.LogResult(result, RequestType.CreateTimeSeries, false);
 
-                using (var queue = tester.Destination.CreateTimeSeriesUploadQueue(TimeSpan.FromSeconds(1), 0, res =>
+                await using (var queue = tester.Destination.CreateTimeSeriesUploadQueue(TimeSpan.FromSeconds(1), 0, res =>
                 {
                     dpCount += res.Uploaded?.Count() ?? 0;
                     cbCount++;

--- a/ExtractorUtils.Test/unit/CdfRawTest.cs
+++ b/ExtractorUtils.Test/unit/CdfRawTest.cs
@@ -117,7 +117,7 @@ namespace ExtractorUtils.Test.Unit
                 var cogniteDestination = provider.GetRequiredService<CogniteDestination>();
                 var logger = provider.GetRequiredService<ILogger<CdfRawTest>>();
                 // queue with 1 sec upload interval
-                using (var queue = cogniteDestination.CreateRawUploadQueue<TestDto>(_dbName, _tableName, TimeSpan.FromSeconds(1)))
+                await using (var queue = cogniteDestination.CreateRawUploadQueue<TestDto>(_dbName, _tableName, TimeSpan.FromSeconds(1)))
                 {
                     var enqueueTask = Task.Run(async () => {
                         while (index < 13)
@@ -145,7 +145,7 @@ namespace ExtractorUtils.Test.Unit
                         ItExpr.IsAny<CancellationToken>());
 
                 // queue with maximum size
-                using (var queue = cogniteDestination.CreateRawUploadQueue<TestDto>(_dbName, _tableName, TimeSpan.FromMinutes(10), 5))
+                await using (var queue = cogniteDestination.CreateRawUploadQueue<TestDto>(_dbName, _tableName, TimeSpan.FromMinutes(10), 5))
                 {
                     var enqueueTask = Task.Run(async () => {
                         while (index < 23)

--- a/ExtractorUtils.Test/unit/DatapointsTest.cs
+++ b/ExtractorUtils.Test/unit/DatapointsTest.cs
@@ -251,7 +251,7 @@ namespace ExtractorUtils.Test.Unit
                 var cogniteDestination = provider.GetRequiredService<CogniteDestination>();
                 var logger = provider.GetRequiredService<ILogger<DatapointsTest>>();
                 // queue with 1 sec upload interval
-                using (var queue = cogniteDestination.CreateTimeSeriesUploadQueue(TimeSpan.FromSeconds(1), 0, res =>
+                await using (var queue = cogniteDestination.CreateTimeSeriesUploadQueue(TimeSpan.FromSeconds(1), 0, res =>
                 {
                     dpCount += res.Uploaded?.Count() ?? 0;
                     cbCount++;
@@ -281,7 +281,7 @@ namespace ExtractorUtils.Test.Unit
                 cbCount = 0;
 
                 // queue with maximum size
-                using (var queue = cogniteDestination.CreateTimeSeriesUploadQueue(TimeSpan.FromMinutes(10), 5, res =>
+                await using (var queue = cogniteDestination.CreateTimeSeriesUploadQueue(TimeSpan.FromMinutes(10), 5, res =>
                 {
                     dpCount += res.Uploaded?.Count() ?? 0;
                     cbCount++;
@@ -365,7 +365,7 @@ namespace ExtractorUtils.Test.Unit
                 var cogniteDestination = provider.GetRequiredService<CogniteDestination>();
                 var logger = provider.GetRequiredService<ILogger<DatapointsTest>>();
                 // queue that will not upload automatically.
-                using (var queue = cogniteDestination.CreateTimeSeriesUploadQueue(TimeSpan.Zero, 0, null, "dp-buffer.bin"))
+                await using (var queue = cogniteDestination.CreateTimeSeriesUploadQueue(TimeSpan.Zero, 0, null, "dp-buffer.bin"))
                 {
                     var _ = queue.Start(CancellationToken.None);
                     for (int i = 0; i < 10; i++)

--- a/ExtractorUtils.Test/unit/EventTest.cs
+++ b/ExtractorUtils.Test/unit/EventTest.cs
@@ -155,7 +155,7 @@ namespace ExtractorUtils.Test.Unit
                 var cogniteDestination = provider.GetRequiredService<CogniteDestination>();
                 var logger = provider.GetRequiredService<ILogger<EventTest>>();
                 // queue with 1 sec upload interval
-                using (var queue = cogniteDestination.CreateEventUploadQueue(TimeSpan.FromSeconds(1), 0, res =>
+                await using (var queue = cogniteDestination.CreateEventUploadQueue(TimeSpan.FromSeconds(1), 0, res =>
                 {
                     evtCount += res.Uploaded?.Count() ?? 0;
                     cbCount++;
@@ -188,7 +188,7 @@ namespace ExtractorUtils.Test.Unit
                 cbCount = 0;
 
                 // queue with maximum size
-                using (var queue = cogniteDestination.CreateEventUploadQueue(TimeSpan.FromMinutes(10), 5, res =>
+                await using (var queue = cogniteDestination.CreateEventUploadQueue(TimeSpan.FromMinutes(10), 5, res =>
                 {
                     evtCount += res.Uploaded?.Count() ?? 0;
                     cbCount++;
@@ -262,7 +262,7 @@ namespace ExtractorUtils.Test.Unit
             {
                 var cogniteDestination = provider.GetRequiredService<CogniteDestination>();
                 var logger = provider.GetRequiredService<ILogger<EventTest>>();
-                using (var queue = cogniteDestination.CreateEventUploadQueue(TimeSpan.Zero, 0, null, "event-buffer.bin"))
+                await using (var queue = cogniteDestination.CreateEventUploadQueue(TimeSpan.Zero, 0, null, "event-buffer.bin"))
                 {
                     var _ = queue.Start(source.Token);
                     for (int i = 0; i < 10; i++)

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -12,10 +12,8 @@ namespace Cognite.Extractor.Utils
     /// <summary>
     /// Base class for extractors writing timeseries, events or datapoints.
     /// </summary>
-    public abstract class BaseExtractor : IDisposable
+    public abstract class BaseExtractor : IDisposable, IAsyncDisposable
     {
-        private bool disposedValue;
-
         /// <summary>
         /// Configuration object
         /// </summary>
@@ -259,29 +257,42 @@ namespace Cognite.Extractor.Utils
         /// <param name="disposing">True if disposing</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (disposing)
             {
-                if (disposing)
+                try
                 {
-                    try
-                    {
-                        // Cannot be allowed to fail here
-                        Scheduler.ExitAllAndWait().Wait();
-                    } catch { }
-                    Scheduler.Dispose();
-                    EventUploadQueue?.Dispose();
-                    TSUploadQueue?.Dispose();
-                    foreach (var queue in RawUploadQueues.Values)
-                    {
-                        queue.Dispose();
-                    }
-                    RawUploadQueues.Clear();
-                    Source.Cancel();
-                    Source.Dispose();
+                    // Cannot be allowed to fail here
+                    Scheduler.ExitAllAndWait().Wait();
+                } catch { }
+                Scheduler.Dispose();
+                EventUploadQueue?.Dispose();
+                TSUploadQueue?.Dispose();
+                foreach (var queue in RawUploadQueues.Values)
+                {
+                    queue.Dispose();
                 }
-
-                disposedValue = true;
+                RawUploadQueues.Clear();
+                Source.Cancel();
+                Source.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Internal method to dispose asynchronously. Preferred.
+        /// </summary>
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            await Scheduler.ExitAllAndWait().ConfigureAwait(false);
+            Scheduler.Dispose();
+            if (EventUploadQueue != null) await EventUploadQueue.DisposeAsync().ConfigureAwait(false);
+            if (TSUploadQueue != null) await TSUploadQueue.DisposeAsync().ConfigureAwait(false);
+            foreach (var queue in RawUploadQueues.Values)
+            {
+                if (queue != null) await queue.DisposeAsync().ConfigureAwait(false);
+            }
+            RawUploadQueues.Clear();
+            Source.Cancel();
+            Source.Dispose();
         }
 
         /// <summary>
@@ -292,6 +303,18 @@ namespace Cognite.Extractor.Utils
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Dispose extractor asynchronously. Preferred.
+        /// </summary>
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+            Dispose(false);
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+            GC.SuppressFinalize(this);
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
         }
     }
 }

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -253,6 +253,7 @@ namespace Cognite.Extractor.Utils
 
         /// <summary>
         /// Dispose of extractor, waiting for running tasks and pushing everything pending to CDF.
+        /// Use DisposeAsync instead if possible.
         /// </summary>
         /// <param name="disposing">True if disposing</param>
         protected virtual void Dispose(bool disposing)
@@ -278,7 +279,7 @@ namespace Cognite.Extractor.Utils
         }
 
         /// <summary>
-        /// Internal method to dispose asynchronously. Preferred.
+        /// Internal method to dispose asynchronously.
         /// </summary>
         protected virtual async ValueTask DisposeAsyncCore()
         {
@@ -296,7 +297,7 @@ namespace Cognite.Extractor.Utils
         }
 
         /// <summary>
-        /// Dispose extractor.
+        /// Dispose extractor. Use DisposeAsync instead if possible.
         /// </summary>
         public void Dispose()
         {
@@ -306,7 +307,7 @@ namespace Cognite.Extractor.Utils
         }
 
         /// <summary>
-        /// Dispose extractor asynchronously. Preferred.
+        /// Dispose extractor asynchronously. Preferred over synchronous dispose.
         /// </summary>
         public async ValueTask DisposeAsync()
         {

--- a/ExtractorUtils/queues/BaseUploadQueue.cs
+++ b/ExtractorUtils/queues/BaseUploadQueue.cs
@@ -305,7 +305,7 @@ namespace Cognite.Extractor.Utils
         }
 
         /// <summary>
-        /// Dispose of the queue, uploading all remaining entries.
+        /// Dispose of the queue, uploading all remaining entries. Use DisposeAsync instead if possible.
         /// </summary>
         public void Dispose()
         {
@@ -314,7 +314,7 @@ namespace Cognite.Extractor.Utils
         }
 
         /// <summary>
-        /// Dispose of the queue, uploading all remaining entries
+        /// Dispose of the queue, uploading all remaining entries. Preferred over synchronous dispose.
         /// </summary>
         public async ValueTask DisposeAsync()
         {


### PR DESCRIPTION
This has caused issues in the past. Calling code asynchronously in Dispose() can cause a deadlock in some circumstances. Using IAsyncDisposable (hopefully) avoid this.