### PR TITLE
Add option to pass pre-created config object

### DIFF
--- a/ExtractorUtils/Configuration/Configuration.cs
+++ b/ExtractorUtils/Configuration/Configuration.cs
@@ -55,6 +55,7 @@ namespace Cognite.Extractor.Utils
         /// <param name="addStateStore">True to add state store, used if extractor reads history</param>
         /// <param name="addLogger">True to add logger</param>
         /// <param name="addMetrics">True to add metrics</param>
+        /// <param name="config">Optional pre-defined config object to use instead of reading from file</param>
         /// <exception cref="ConfigurationException">Thrown when the version is not valid, 
         /// the yaml file is not found or in case of yaml parsing error</exception>
         /// <returns>Configuration object</returns>
@@ -66,9 +67,23 @@ namespace Cognite.Extractor.Utils
             string userAgent,
             bool addStateStore,
             bool addLogger = true,
-            bool addMetrics = true) where T : VersionedConfig
+            bool addMetrics = true,
+            T config = null) where T : VersionedConfig
         {
-            var config = services.AddConfig<T>(configPath, acceptedConfigVersions);
+            if (config != null)
+            {
+                services.AddSingleton(config);
+                services.AddConfig(config,
+                    typeof(CogniteConfig),
+                    typeof(LoggerConfig),
+                    typeof(MetricsConfig),
+                    typeof(StateStoreConfig),
+                    typeof(BaseConfig));
+            }
+            else if (configPath != null)
+            {
+                config = services.AddConfig<T>(configPath, acceptedConfigVersions);
+            }
             services.AddCogniteClient(appId, userAgent, addLogger, addMetrics);
             if (addStateStore) services.AddStateStore();
             if (addLogger) services.AddLogger();

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -23,7 +23,8 @@ namespace Cognite.Extractor.Utils
         /// </summary>
         /// <typeparam name="TConfig">Type of configuration</typeparam>
         /// <typeparam name="TExtractor">Type of extractor</typeparam>
-        /// <param name="configPath">Path to yml config file</param>
+        /// <param name="configPath">Path to yml config file. Can be null to not load config, in this case
+        /// <paramref name="config" /> must be set, or the config must be added to <paramref name="extServices"/></param>
         /// <param name="acceptedConfigVersions">List of accepted config versions, null accepts all</param>
         /// <param name="appId">AppId to append to requests to CDF</param>
         /// <param name="userAgent">User agent on form Product/Version</param>
@@ -39,6 +40,7 @@ namespace Cognite.Extractor.Utils
         /// invalid</param>
         /// <param name="extServices">Optional pre-configured service collection</param>
         /// <param name="startupLogger">Optional logger to use before config has been loaded, to report configuration issues</param>
+        /// <param name="config">Optional pre-existing config object, can be used instead of config path.</param>
         /// <returns>Task which completes when the extractor has run</returns>
         public static async Task Run<TConfig, TExtractor>(
             string configPath,
@@ -53,7 +55,8 @@ namespace Cognite.Extractor.Utils
             Action<CogniteDestination, TExtractor> onCreateExtractor = null,
             Action<TConfig> configCallback = null,
             ServiceCollection extServices = null,
-            ILogger startupLogger = null)
+            ILogger startupLogger = null,
+            TConfig config = null)
             where TConfig : VersionedConfig
             where TExtractor : BaseExtractor
         {
@@ -87,7 +90,7 @@ namespace Cognite.Extractor.Utils
                     ConfigurationException exception = null;
                     try
                     {
-                        var config = services.AddExtractorDependencies<TConfig>(configPath, acceptedConfigVersions,
+                        config = services.AddExtractorDependencies<TConfig>(configPath, acceptedConfigVersions,
                             appId, userAgent, addStateStore, addLogger, addMetrics);
                         configCallback?.Invoke(config);
                     }


### PR DESCRIPTION
This is useful in cases where there the extractor is designed to run without config file, or if the config is obtained from elsewhere somehow.