### PR TITLE
Allow scheduling tasks without running them immediately

### DIFF
--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -249,7 +249,7 @@ namespace ExtractorUtils.Test.Unit
             // Assert.False(task.IsFaulted);
         }
 
-        [Fact(Timeout = 20000)]
+        [Fact(Timeout = 200000)]
         public async Task TestPeriodicScheduler()
         {
             using var source = new CancellationTokenSource();
@@ -304,11 +304,23 @@ namespace ExtractorUtils.Test.Unit
             // It might run once more, if it was already scheduled to run
             Assert.True(periodicRuns <= numRuns + 1);
 
-
             // Exit periodic and wait
             await RunWithTimeout(scheduler.ExitAndWaitForTermination("periodic"), 1000);
-            source.Cancel();
 
+            // Test waiting to run
+            int infRuns = 0;
+            scheduler.SchedulePeriodicTask("infinitePeriodic", Timeout.InfiniteTimeSpan, token =>
+            {
+                infRuns++;
+            }, false);
+
+            await Task.Delay(400);
+            Assert.Equal(0, infRuns);
+            scheduler.TriggerTask("infinitePeriodic");
+            await Task.Delay(400);
+            Assert.Equal(1, infRuns);
+
+            source.Cancel();
             await RunWithTimeout(scheduler.WaitForAll(), 1000);
         }
     }


### PR DESCRIPTION
This work also uncovered some really problematic stuff related to async testing and xunit. It turns out xunit uses a really strict task scheduler which easily deadlocks if you _happen to have too many tasks blocking_ independent really of ConfigureAwait, etc.

This makes the tests sometimes magically deadlock for no apparent reason, but it shouldn't really happen outside of a custom threading context.

This is not unusual. Xunit devs are known for making decisions that impose arbitrary restrictions on users in order to dictate their worldview, and refusing to provide a reasonable workaround. https://github.com/xunit/xunit/issues/864