### PR TITLE
Schedule without running

### DIFF
--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -249,7 +249,7 @@ namespace ExtractorUtils.Test.Unit
             // Assert.False(task.IsFaulted);
         }
 
-        [Fact(Timeout = 20000)]
+        [Fact(Timeout = 200000)]
         public async Task TestPeriodicScheduler()
         {
             using var source = new CancellationTokenSource();
@@ -304,11 +304,23 @@ namespace ExtractorUtils.Test.Unit
             // It might run once more, if it was already scheduled to run
             Assert.True(periodicRuns <= numRuns + 1);
 
-
             // Exit periodic and wait
             await RunWithTimeout(scheduler.ExitAndWaitForTermination("periodic"), 1000);
-            source.Cancel();
 
+            // Test waiting to run
+            int infRuns = 0;
+            scheduler.SchedulePeriodicTask("infinitePeriodic", Timeout.InfiniteTimeSpan, token =>
+            {
+                infRuns++;
+            }, false);
+
+            await Task.Delay(400);
+            Assert.Equal(0, infRuns);
+            scheduler.TriggerTask("infinitePeriodic");
+            await Task.Delay(400);
+            Assert.Equal(1, infRuns);
+
+            source.Cancel();
             await RunWithTimeout(scheduler.WaitForAll(), 1000);
         }
     }


### PR DESCRIPTION
The feature is just an option to start a new periodic task without running it immediately, which is a very common use-case.

The reason why the diff is so large is that this exposed a very ugly issue that I'm still not entirely sure how happens. There seems to be some sort of deadlock when trying to asynchronously for many tasks. It _might_ be isolated to xunit, which is known to do some weird stuff with threading. It might also be related to the WaitAsync method, but attempts to fix it there did not help.

The solution which finally fixed it was manually reporting task completion once the periodic loop terminates, and not wait for the task to complete on its own. Practically there should be no real difference, except that we remove a "layer" of task completions, and force the task to complete so long as the method is allowed to run. In theory the task itself should be cleaned up. If this is indeed caused by a deadlock when awaiting tasks, not awaiting the task should solve the issue.