### PR TITLE
Optionally report success on startup of extractor run

### DIFF
--- a/ExtractorUtils.Test/integration/ExtractorTest.cs
+++ b/ExtractorUtils.Test/integration/ExtractorTest.cs
@@ -254,6 +254,7 @@ namespace ExtractorUtils.Test.Integration
                     Frequency = 1,
                     PipelineId = id
                 }, tester.Destination, tester.Provider.GetService<ILogger<ExtractionRun>>());
+                run.Continuous = true;
                 run.Start();
                 await Task.Delay(1000);
 
@@ -267,11 +268,11 @@ namespace ExtractorUtils.Test.Integration
                             ExternalId = id
                         }
                     });
-                    if (runs.Items.Count() > 1) break;
+                    if (runs.Items.Count() > 1 && runs.Items.Any(item => item.Status == ExtPipeRunStatus.success)) break;
                     await Task.Delay(1000);
                 }
 
-                Assert.True(runs.Items.Count() > 1);
+                Assert.True(runs.Items.Count() > 1 && runs.Items.Any(item => item.Status == ExtPipeRunStatus.success));
 
                 await run.Report(ExtPipeRunStatus.failure, false, "Some failure");
                 await run.DisposeAsync();
@@ -287,7 +288,7 @@ namespace ExtractorUtils.Test.Integration
                         }
                     });
                     if (runs.Items.Count() > 3 && runs.Items.Any(run => run.Status == ExtPipeRunStatus.failure)
-                        && runs.Items.Any(run => run.Status == ExtPipeRunStatus.success)) break;
+                        && runs.Items.Count(run => run.Status == ExtPipeRunStatus.success) > 1) break;
                     await Task.Delay(1000);
                 }
 

--- a/ExtractorUtils.Test/integration/ExtractorTest.cs
+++ b/ExtractorUtils.Test/integration/ExtractorTest.cs
@@ -254,7 +254,7 @@ namespace ExtractorUtils.Test.Integration
                     Frequency = 1,
                     PipelineId = id
                 }, tester.Destination, tester.Provider.GetService<ILogger<ExtractionRun>>());
-
+                run.Start();
                 await Task.Delay(1000);
 
                 ItemsWithCursor<ExtPipeRun> runs = null;

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -116,7 +116,10 @@ namespace Cognite.Extractor.Utils
             finally
             {
                 await OnStop().ConfigureAwait(false);
-                await Run.DisposeAsync().ConfigureAwait(false);
+                if (Run != null)
+                {
+                    await Run.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
 

--- a/ExtractorUtils/BaseExtractor.cs
+++ b/ExtractorUtils/BaseExtractor.cs
@@ -48,17 +48,29 @@ namespace Cognite.Extractor.Utils
         /// Access to the service provider this extractor was built from
         /// </summary>
         protected IServiceProvider Provider { get; private set; }
+
+        /// <summary>
+        /// Extraction run for reporting to an extraction pipeline in CDF.
+        /// </summary>
+        protected ExtractionRun Run { get; }
+
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="config">Configuration object</param>
         /// <param name="destination">Cognite destination</param>
         /// <param name="provider">Service provider</param>
-        public BaseExtractor(BaseConfig config, CogniteDestination destination, IServiceProvider provider)
+        /// <param name="run">Optional extraction run</param>
+        public BaseExtractor(
+            BaseConfig config,
+            CogniteDestination destination,
+            IServiceProvider provider,
+            ExtractionRun run = null)
         {
             Config = config;
             Destination = destination;
             Provider = provider;
+            Run = run;
         }
 
         /// <summary>
@@ -73,6 +85,7 @@ namespace Cognite.Extractor.Utils
         /// <summary>
         /// Method called to start the extractor.
         /// </summary>
+        /// <param name="token">Cancellation token</param>
         /// <returns></returns>
         public virtual async Task Start(CancellationToken token)
         {
@@ -84,17 +97,34 @@ namespace Cognite.Extractor.Utils
             try
             {
                 await Start().ConfigureAwait(false);
+                if (Run != null)
+                {
+                    Run.Start();
+                }
                 await Scheduler.WaitForAll().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (token.IsCancellationRequested) return;
+                if (Run != null)
+                {
+                    await Run.Report(ExtPipeRunStatus.failure, true,
+                        $"Error: {ex.Message}\n{ex.StackTrace}", token).ConfigureAwait(false);
+                }
+                throw;
             }
             finally
             {
                 await OnStop().ConfigureAwait(false);
+                await Run.DisposeAsync().ConfigureAwait(false);
             }
         }
 
         /// <summary>
         /// Internal method starting the extractor. Should handle any creation of timeseries,
         /// setup of source systems, and calls to the various Schedule and Create protected methods.
+        /// Should not be the actual extraction. Start should return once the extractor has successfully started.
+        /// Other tasks can be scheduled in the PeriodicScheduler.
         /// </summary>
         /// <returns></returns>
         protected abstract Task Start();

--- a/ExtractorUtils/ExtractionRun.cs
+++ b/ExtractorUtils/ExtractionRun.cs
@@ -22,10 +22,6 @@ namespace Cognite.Extractor.Utils
         /// Frequency of extraction pipeline updates in seconds.
         /// </summary>
         public int Frequency { get; set; } = 600;
-        /// <summary>
-        /// True if this is a continuous extractor. This means that it should report success after the extractor is started.
-        /// </summary>
-        public bool Continuous { get; set; }
     }
 
     /// <summary>
@@ -39,6 +35,12 @@ namespace Cognite.Extractor.Utils
         private CancellationTokenSource _source = new CancellationTokenSource();
         private CogniteDestination _destination;
         private ILogger<ExtractionRun> _log = new NullLogger<ExtractionRun>();
+
+        /// <summary>
+        /// True if this is a continuous extractor. This means that it should report success after the extractor is started.
+        /// </summary>
+        public bool Continuous { get; set; }
+
         /// <summary>
         /// Constructor, can be called from dependency injection if <see cref="ExtractionRunConfig"/> has been injected.
         /// </summary>
@@ -76,7 +78,7 @@ namespace Cognite.Extractor.Utils
                 return;
             }
 
-            if (_config.Continuous)
+            if (Continuous)
             {
                 try
                 {

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -62,161 +62,160 @@ namespace Cognite.Extractor.Utils
         {
             int waitRepeats = 1;
 
-            using (var source = CancellationTokenSource.CreateLinkedTokenSource(token))
+            using var source = CancellationTokenSource.CreateLinkedTokenSource(token);
+            void CancelKeyPressHandler(object sender, ConsoleCancelEventArgs eArgs)
             {
-                void CancelKeyPressHandler(object sender, ConsoleCancelEventArgs eArgs)
+                eArgs.Cancel = true;
+                try
                 {
-                    eArgs.Cancel = true;
-                    try
+                    source?.Cancel();
+                }
+                catch { }
+            }
+
+            Console.CancelKeyPress += CancelKeyPressHandler;
+            while (!source.IsCancellationRequested)
+            {
+                var services = new ServiceCollection();
+
+                if (extServices != null)
+                {
+                    foreach (var service in extServices)
                     {
-                        source?.Cancel();
+                        services.Add(service);
                     }
-                    catch { }
                 }
 
-                Console.CancelKeyPress += CancelKeyPressHandler;
-                while (!source.IsCancellationRequested)
+                ConfigurationException exception = null;
+                try
                 {
-                    var services = new ServiceCollection();
-                       
-                    if (extServices != null)
-                    {
-                        foreach (var service in extServices)
-                        {
-                            services.Add(service);
-                        }
-                    }
+                    config = services.AddExtractorDependencies<TConfig>(configPath, acceptedConfigVersions,
+                        appId, userAgent, addStateStore, addLogger, addMetrics);
+                    configCallback?.Invoke(config);
+                }
+                catch (AggregateException ex)
+                {
+                    exception = ex.Flatten().InnerExceptions.OfType<ConfigurationException>().First();
+                }
+                catch (ConfigurationException ex)
+                {
+                    exception = ex;
+                }
 
-                    ConfigurationException exception = null;
+                if (exception != null)
+                {
+                    if (startupLogger != null)
+                    {
+                        startupLogger.LogError("Invalid configuration file: {msg}", exception.Message);
+                        if (!restart) startupLogger.LogInformation("Sleeping for 30 seconds");
+                    }
+                    else
+                    {
+                        Serilog.Log.Logger = LoggingUtils.GetSerilogDefault();
+                        Serilog.Log.Error("Invalid configuration file: " + exception.Message);
+                        if (!restart) Serilog.Log.Information("Sleeping for 30 seconds");
+                    }
+                    if (!restart) break;
                     try
                     {
-                        config = services.AddExtractorDependencies<TConfig>(configPath, acceptedConfigVersions,
-                            appId, userAgent, addStateStore, addLogger, addMetrics);
-                        configCallback?.Invoke(config);
+                        await Task.Delay(30_000, source.Token).ConfigureAwait(false);
                     }
-                    catch (AggregateException ex)
+                    catch { }
+                    continue;
+                }
+
+                services.AddSingleton<TExtractor>();
+                services.AddSingleton<BaseExtractor>(prov => prov.GetRequiredService<TExtractor>());
+                DateTime startTime = DateTime.UtcNow;
+                ILogger<BaseExtractor> log;
+
+                var provider = services.BuildServiceProvider();
+                await using (provider.ConfigureAwait(false))
+                {
+                    log = new NullLogger<BaseExtractor>();
+                    TExtractor extractor = null;
+                    try
                     {
-                        exception = ex.Flatten().InnerExceptions.OfType<ConfigurationException>().First();
+                        if (addMetrics)
+                        {
+                            var metrics = provider.GetRequiredService<MetricsService>();
+                            metrics.Start();
+                        }
+                        if (addLogger)
+                        {
+                            log = provider.GetRequiredService<ILogger<BaseExtractor>>();
+                            Serilog.Log.Logger = provider.GetRequiredService<Serilog.ILogger>();
+                        }
+                        extractor = provider.GetRequiredService<TExtractor>();
+                        if (onCreateExtractor != null)
+                        {
+                            var destination = provider.GetRequiredService<CogniteDestination>();
+                            onCreateExtractor(destination, extractor);
+                        }
                     }
-                    catch (ConfigurationException ex)
+                    catch (Exception ex)
                     {
-                        exception = ex;
+                        log.LogError("Failed to build extractor: {msg}", ex.Message);
                     }
 
-                    if (exception != null)
+                    if (extractor != null)
                     {
-                        if (startupLogger != null)
-                        {
-                            startupLogger.LogError("Invalid configuration file: " + exception.Message);
-                            if (!restart) startupLogger.LogInformation("Sleeping for 30 seconds");
-                        }
-                        else
-                        {
-                            Serilog.Log.Logger = LoggingUtils.GetSerilogDefault();
-                            Serilog.Log.Error("Invalid configuration file: " + exception.Message);
-                            if (!restart) Serilog.Log.Information("Sleeping for 30 seconds");
-                        }
-                        if (!restart) break;
                         try
                         {
-                            await Task.Delay(30_000, source.Token).ConfigureAwait(false);
-                        } catch { }
-                        continue;
-                    }
-
-                    services.AddSingleton<TExtractor>();
-                    services.AddSingleton<BaseExtractor>(prov => prov.GetRequiredService<TExtractor>());
-                    DateTime startTime = DateTime.UtcNow;
-                    ILogger<BaseExtractor> log;
-
-                    var provider = services.BuildServiceProvider();
-                    await using (provider.ConfigureAwait(false))
-                    {
-                        log = new NullLogger<BaseExtractor>();
-                        TExtractor extractor = null;
-                        try
+                            await extractor.Start(source.Token).ConfigureAwait(false);
+                        }
+                        catch (TaskCanceledException) when (source.IsCancellationRequested)
                         {
-                            if (addMetrics)
-                            {
-                                var metrics = provider.GetRequiredService<MetricsService>();
-                                metrics.Start();
-                            }
-                            if (addLogger)
-                            {
-                                log = provider.GetRequiredService<ILogger<BaseExtractor>>();
-                                Serilog.Log.Logger = provider.GetRequiredService<Serilog.ILogger>();
-                            }
-                            extractor = provider.GetRequiredService<TExtractor>();
-                            if (onCreateExtractor != null)
-                            {
-                                var destination = provider.GetRequiredService<CogniteDestination>();
-                                onCreateExtractor(destination, extractor);
-                            }
+                            log.LogWarning("Extractor stopped manually");
                         }
                         catch (Exception ex)
                         {
-                            log.LogError("Failed to build extractor: " + ex.Message);
-                        }
+                            // Make the stack trace a little cleaner. We generally don't need the whole task stack.
+                            if (ex is AggregateException aex) ex = aex.Flatten().InnerExceptions.First();
 
-                        if (extractor != null)
-                        {
-                            try
-                            {
-                                await extractor.Start(source.Token).ConfigureAwait(false);
-                            }
-                            catch (TaskCanceledException) when (source.IsCancellationRequested)
+                            if (source.IsCancellationRequested)
                             {
                                 log.LogWarning("Extractor stopped manually");
                             }
-                            catch (Exception ex)
+                            else
                             {
-                                // Make the stack trace a little cleaner. We generally don't need the whole task stack.
-                                if (ex is AggregateException aex) ex = aex.Flatten().InnerExceptions.First();
-
-                                if (source.IsCancellationRequested)
-                                {
-                                    log.LogWarning("Extractor stopped manually");
-                                }
-                                else
-                                {
-                                    log.LogError(ex, "Extractor crashed unexpectedly");
-                                }
+                                log.LogError(ex, "Extractor crashed unexpectedly");
                             }
-                        }
-
-
-                        if (source.IsCancellationRequested || !restart)
-                        {
-                            log.LogInformation("Quitting extractor");
-                            break;
-                        }
-
-                        if (startTime > DateTime.UtcNow - TimeSpan.FromSeconds(600))
-                        {
-                            waitRepeats++;
-                        }
-                        else
-                        {
-                            waitRepeats = 1;
-                        }
-
-                        try
-                        {
-                            var sleepTime = TimeSpan.FromSeconds(Math.Pow(2, Math.Min(waitRepeats, 9)));
-                            log.LogInformation("Sleeping for {time}", sleepTime);
-                            Task.Delay(sleepTime, source.Token).Wait();
-                        }
-                        catch (Exception)
-                        {
-                            log.LogWarning("Extractor stopped manually");
-                            break;
                         }
                     }
 
-                    
+
+                    if (source.IsCancellationRequested || !restart)
+                    {
+                        log.LogInformation("Quitting extractor");
+                        break;
+                    }
+
+                    if (startTime > DateTime.UtcNow - TimeSpan.FromSeconds(600))
+                    {
+                        waitRepeats++;
+                    }
+                    else
+                    {
+                        waitRepeats = 1;
+                    }
+
+                    try
+                    {
+                        var sleepTime = TimeSpan.FromSeconds(Math.Pow(2, Math.Min(waitRepeats, 9)));
+                        log.LogInformation("Sleeping for {time}", sleepTime);
+                        Task.Delay(sleepTime, source.Token).Wait();
+                    }
+                    catch (Exception)
+                    {
+                        log.LogWarning("Extractor stopped manually");
+                        break;
+                    }
                 }
-                Console.CancelKeyPress -= CancelKeyPressHandler;
+
+
             }
+            Console.CancelKeyPress -= CancelKeyPressHandler;
         }
 
 


### PR DESCRIPTION
This required some changes to the startup, but the final solution is generally better. Now the extractor itself is responsible for the run, and not the ExtractorRunner Run method. This is more general and useful if users don't want to use the Run method.