### PR TITLE
Scheduler error handling

### DIFF
--- a/Cognite.Common/PeriodicScheduler.cs
+++ b/Cognite.Common/PeriodicScheduler.cs
@@ -238,7 +238,6 @@ namespace Cognite.Extractor.Common
                 {
                     failedTask = _tasks.Values.FirstOrDefault(kvp => kvp.Task.IsFaulted);
 
-                    Console.WriteLine("Failing: " + failedTask?.Name);
                     if (failedTask != null) break;
                     if (_source.IsCancellationRequested) break;
 


### PR DESCRIPTION
Improved ability to handle errors in PeriodicScheduler. It was too difficult to know whether a task existed or not, and what to do about it. This adds the option to pass tasks without name, and check whether a task with a given name exists.

It also fixes a bug where thrown errors were not properly reported.