### PR TITLE
Allow building the extractor without a cognite destination

### DIFF
--- a/Cognite.Extensions/CogniteUtils.cs
+++ b/Cognite.Extensions/CogniteUtils.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cognite.Extensions
 {
@@ -545,6 +546,7 @@ namespace Cognite.Extensions
             int? maxRetries,
             int? maxDelay)
         {
+            logger = logger ?? new NullLogger<Client>();
             int numRetries = maxRetries ?? 5;
             int delay = maxDelay ?? 5_000;
             if (maxDelay < 0) maxDelay = int.MaxValue;

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -10,8 +10,8 @@ using Cognite.Extractor.Common;
 
 class MyExtractor : BaseExtractor
 {
-    public MyExtractor(BaseConfig config, CogniteDestination destination, IServiceProvider provider)
-        : base(config, destination, provider)
+    public MyExtractor(BaseConfig config, IServiceProvider provider, CogniteDestination destination)
+        : base(config, provider, destination)
     {
     }
 

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -41,6 +41,7 @@ namespace Cognite.Extractor.Utils
         /// <param name="extServices">Optional pre-configured service collection</param>
         /// <param name="startupLogger">Optional logger to use before config has been loaded, to report configuration issues</param>
         /// <param name="config">Optional pre-existing config object, can be used instead of config path.</param>
+        /// <param name="requireDestination">Default true, whether to fail if a destination cannot be configured</param>
         /// <returns>Task which completes when the extractor has run</returns>
         public static async Task Run<TConfig, TExtractor>(
             string configPath,
@@ -56,7 +57,8 @@ namespace Cognite.Extractor.Utils
             Action<TConfig> configCallback = null,
             ServiceCollection extServices = null,
             ILogger startupLogger = null,
-            TConfig config = null)
+            TConfig config = null,
+            bool requireDestination = true)
             where TConfig : VersionedConfig
             where TExtractor : BaseExtractor
         {
@@ -89,8 +91,8 @@ namespace Cognite.Extractor.Utils
                 ConfigurationException exception = null;
                 try
                 {
-                    config = services.AddExtractorDependencies<TConfig>(configPath, acceptedConfigVersions,
-                        appId, userAgent, addStateStore, addLogger, addMetrics);
+                    config = services.AddExtractorDependencies(configPath, acceptedConfigVersions,
+                        appId, userAgent, addStateStore, addLogger, addMetrics, requireDestination, config);
                     configCallback?.Invoke(config);
                 }
                 catch (AggregateException ex)


### PR DESCRIPTION
While the utils are really built for pushing to CDF, it is sometimes useful to allow building the extractor without a CogniteDestination, for testing or other purposes. This is a fix that makes it possible to not pass cognite configuration without extractor startup failing.