### PR TITLE
Option to pass method for configuring logger

### DIFF
--- a/Cognite.Extensions/TimeSeries/DataPointExtensions.cs
+++ b/Cognite.Extensions/TimeSeries/DataPointExtensions.cs
@@ -212,7 +212,7 @@ namespace Cognite.Extensions
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogDebug("Failed to create datapoints for {seq} timeseries", points.Count);
+                    _logger.LogDebug("Failed to create datapoints for {seq} timeseries: {msg}", points.Count, ex.Message);
                     var error = ResultHandlers.ParseException<DataPointInsertError>(ex, RequestType.CreateDatapoints);
                     if (error.Complete) errors.Add(error);
                     if (error.Type == ErrorType.FatalFailure

--- a/Cognite.Logging/Logger.cs
+++ b/Cognite.Logging/Logger.cs
@@ -33,7 +33,7 @@ namespace Cognite.Extractor.Logging
         }
 
         /// <summary>
-        /// Creates loggerconfiguration according to the configuration in <paramref name="config"/>
+        /// Creates <see cref="LoggerConfiguration" /> according to the configuration in <paramref name="config"/>
         /// </summary>
         /// <param name="config">Configuration object of <see cref="LoggerConfig"/> type</param>
         /// <returns>A configured logger</returns>
@@ -225,7 +225,7 @@ namespace Cognite.Extractor.Logging
         /// which creates logging configuration for file and console using
         /// <see cref="LoggingUtils.GetConfiguration(LoggerConfig)"/></param>
         public static void AddLogger(this IServiceCollection services, Func<LoggerConfig, Serilog.ILogger>? buildLogger = null) {
-            if (buildLogger == null) buildLogger = LoggingUtils.GetConfiguredLogger;
+            buildLogger ??= LoggingUtils.GetConfiguredLogger;
             services.AddSingleton<LoggerTraceListener>();
             services.AddSingleton<Serilog.ILogger>(p => {
                 var config = p.GetService<LoggerConfig>();

--- a/Cognite.Logging/Logger.cs
+++ b/Cognite.Logging/Logger.cs
@@ -33,11 +33,11 @@ namespace Cognite.Extractor.Logging
         }
 
         /// <summary>
-        /// Creates a <see cref="Serilog.ILogger"/> logger according to the configuration in <paramref name="config"/>
+        /// Creates loggerconfiguration according to the configuration in <paramref name="config"/>
         /// </summary>
         /// <param name="config">Configuration object of <see cref="LoggerConfig"/> type</param>
         /// <returns>A configured logger</returns>
-        public static Serilog.ILogger GetConfiguredLogger(LoggerConfig config)
+        public static LoggerConfiguration GetConfiguration(LoggerConfig config)
         {
             if (config == null)
             {
@@ -64,7 +64,8 @@ namespace Cognite.Extractor.Logging
             if (logToFile && config.File!.Path != null)
             {
                 RollingInterval ri = RollingInterval.Day;
-                if (config.File.RollingInterval == "hour") {
+                if (config.File.RollingInterval == "hour")
+                {
                     ri = RollingInterval.Hour;
                 }
                 logConfig.WriteTo.Async(p => p.File(
@@ -75,6 +76,17 @@ namespace Cognite.Extractor.Logging
                     outputTemplate: fileLevel <= LogEventLevel.Debug ? _logTemplateWithContext : _logTemplate));
             }
 
+            return logConfig;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Serilog.ILogger"/> logger according to the configuration in <paramref name="config"/>
+        /// </summary>
+        /// <param name="config">Configuration object of <see cref="LoggerConfig"/> type</param>
+        /// <returns>A configured logger</returns>
+        public static Serilog.ILogger GetConfiguredLogger(LoggerConfig config)
+        {
+            var logConfig = GetConfiguration(config);
             return logConfig.CreateLogger();
         }
 
@@ -200,7 +212,7 @@ namespace Cognite.Extractor.Logging
     /// Extension utilities for logging
     /// </summary>
     public static class LoggingExtensions {
-        
+
         /// <summary>
         /// Adds a configured Serilog logger as singletons of the <see cref="Microsoft.Extensions.Logging.ILogger"/> and
         /// <see cref="Serilog.ILogger"/> types to the <paramref name="services"/> collection.
@@ -208,7 +220,12 @@ namespace Cognite.Extractor.Logging
         /// collection as well.
         /// </summary>
         /// <param name="services">The service collection</param>
-        public static void AddLogger(this IServiceCollection services) {
+        /// <param name="buildLogger">Method to build the logger.
+        /// This defaults to <see cref="LoggingUtils.GetConfiguredLogger(LoggerConfig)"/>,
+        /// which creates logging configuration for file and console using
+        /// <see cref="LoggingUtils.GetConfiguration(LoggerConfig)"/></param>
+        public static void AddLogger(this IServiceCollection services, Func<LoggerConfig, Serilog.ILogger>? buildLogger = null) {
+            if (buildLogger == null) buildLogger = LoggingUtils.GetConfiguredLogger;
             services.AddSingleton<LoggerTraceListener>();
             services.AddSingleton<Serilog.ILogger>(p => {
                 var config = p.GetService<LoggerConfig>();
@@ -218,7 +235,7 @@ namespace Cognite.Extractor.Logging
                     defLog.Warning("No Logging configuration found. Using default logger");
                     return defLog;
                 }
-                return LoggingUtils.GetConfiguredLogger(config);
+                return buildLogger(config);
             });
             services.AddLogging(loggingBuilder => {
                 loggingBuilder.Services.AddSingleton<ILoggerProvider, SerilogLoggerProvider>(s => 

--- a/ExtractorUtils/Configuration/Configuration.cs
+++ b/ExtractorUtils/Configuration/Configuration.cs
@@ -4,6 +4,7 @@ using Cognite.Extractor.Logging;
 using Cognite.Extractor.Metrics;
 using Cognite.Extractor.StateStorage;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Cognite.Extractor.Utils
 {
@@ -57,6 +58,8 @@ namespace Cognite.Extractor.Utils
         /// <param name="addMetrics">True to add metrics</param>
         /// <param name="requireDestination">True to fail if a destination cannot be configured</param>
         /// <param name="config">Optional pre-defined config object to use instead of reading from file</param>
+        /// <param name="buildLogger">Optional method to build logger.
+        /// Defaults to <see cref="LoggingUtils.GetConfiguredLogger(LoggerConfig)"/> </param>
         /// <exception cref="ConfigurationException">Thrown when the version is not valid, 
         /// the yaml file is not found or in case of yaml parsing error</exception>
         /// <returns>Configuration object</returns>
@@ -70,7 +73,8 @@ namespace Cognite.Extractor.Utils
             bool addLogger = true,
             bool addMetrics = true,
             bool requireDestination = true,
-            T? config = null) where T : VersionedConfig
+            T? config = null,
+            Func<LoggerConfig, Serilog.ILogger>? buildLogger = null) where T : VersionedConfig
         {
             if (config != null)
             {
@@ -92,7 +96,7 @@ namespace Cognite.Extractor.Utils
             }
             services.AddCogniteClient(appId, userAgent, addLogger, addMetrics, true, requireDestination);
             if (addStateStore) services.AddStateStore();
-            if (addLogger) services.AddLogger();
+            if (addLogger) services.AddLogger(buildLogger);
             if (addMetrics) services.AddMetrics();
             services.AddExtractionRun(addLogger);
             return config;

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -85,6 +85,10 @@ namespace Cognite.Extractor.Utils
         /// Method to log exceptions. Default is just a simple log message with the exception.
         /// </summary>
         public Action<ILogger, Exception, string>? LogException { get; set; }
+        /// <summary>
+        /// Method to build logger from config. Defaults to <see cref="LoggingUtils.GetConfiguredLogger(LoggerConfig)"/>
+        /// </summary>
+        public Func<LoggerConfig, Serilog.ILogger>? BuildLogger { get; set; }
     }
 
 


### PR DESCRIPTION
This is useful for testing, or for adding other logging destinations. To make this even easier, the method building LoggerConfiguration is also separated so that it can be called externally.