### PR TITLE
Move authenticator

### DIFF
--- a/Cognite.Common/ConfigurationException.cs
+++ b/Cognite.Common/ConfigurationException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Cognite.Extractor.Configuration
+namespace Cognite.Extractor.Common
 {
     /// <summary>
     /// Exception produced by the configuration utils 

--- a/Cognite.Config/Cognite.Configuration.csproj
+++ b/Cognite.Config/Cognite.Configuration.csproj
@@ -28,4 +28,8 @@
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -1,3 +1,4 @@
+using Cognite.Extractor.Common;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;

--- a/Cognite.Extensions/Authenticator.cs
+++ b/Cognite.Extensions/Authenticator.cs
@@ -157,7 +157,7 @@ namespace Cognite.Extensions
         {
             if (config == null)
             {
-                throw new ArgumentNullException(nameof(config));
+                throw new ConfigurationException("Configuration missing");
             }
             _config = config;
             _client = client;

--- a/Cognite.Extensions/Authenticator.cs
+++ b/Cognite.Extensions/Authenticator.cs
@@ -153,7 +153,7 @@ namespace Cognite.Extensions
         /// <param name="config">Configuration object</param>
         /// <param name="client">Http client</param>
         /// <param name="logger">Logger</param>
-        public Authenticator(AuthenticatorConfig config, HttpClient client, ILogger<IAuthenticator> logger)
+        public Authenticator(AuthenticatorConfig config, HttpClient client, ILogger<IAuthenticator>? logger)
         {
             if (config == null)
             {
@@ -161,7 +161,7 @@ namespace Cognite.Extensions
             }
             _config = config;
             _client = client;
-            _logger = logger;
+            _logger = logger ?? new Microsoft.Extensions.Logging.Abstractions.NullLogger<Authenticator>();
 
             if (!string.IsNullOrWhiteSpace(config.TokenUrl))
             {

--- a/Cognite.Extensions/Authenticator.cs
+++ b/Cognite.Extensions/Authenticator.cs
@@ -175,7 +175,7 @@ namespace Cognite.Extensions
             }
             else
             {
-                throw new ArgumentException("No OIDC tenant or token url defined");
+                throw new ConfigurationException("No OIDC tenant or token url defined");
             }
         }
 

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CogniteSdk" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
     <PackageReference Include="prometheus-net" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />

--- a/Cognite.Extensions/MsalAuthenticator.cs
+++ b/Cognite.Extensions/MsalAuthenticator.cs
@@ -3,12 +3,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
-using Cognite.Extensions;
 using Cognite.Extractor.Common;
 using System.Net.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Cognite.Extractor.Utils
+namespace Cognite.Extensions
 {
     /// <summary>
     /// Uses Microsoft Authentication Library (MSAL) to acquire tokens from the identity provider endpoint

--- a/ExtractorUtils.Test/CDFTester.cs
+++ b/ExtractorUtils.Test/CDFTester.cs
@@ -64,13 +64,8 @@ namespace ExtractorUtils.Test
                 case CogniteHost.GreenField:
                     config = config.Concat(new List<String>() {
                         "  project: ${TEST_PROJECT}",
-                        "  host: ${TEST_HOST}",
-                        "  idp-authentication:",
-                        "    client-id: ${TEST_CLIENT_ID}",
-                        "    tenant: ${TEST_TENANT}",
-                        "    secret: ${TEST_SECRET}",
-                        "    scopes:",
-                        "    - ${TEST_SCOPE}"
+                        "  api-key: ${TEST_API_KEY}",
+                        "  host: ${TEST_HOST}"
                     }).ToList();
                     break;
                 case CogniteHost.BlueField:

--- a/ExtractorUtils.Test/CDFTester.cs
+++ b/ExtractorUtils.Test/CDFTester.cs
@@ -64,8 +64,13 @@ namespace ExtractorUtils.Test
                 case CogniteHost.GreenField:
                     config = config.Concat(new List<String>() {
                         "  project: ${TEST_PROJECT}",
-                        "  api-key: ${TEST_API_KEY}",
-                        "  host: ${TEST_HOST}"
+                        "  host: ${TEST_HOST}",
+                        "  idp-authentication:",
+                        "    client-id: ${TEST_CLIENT_ID}",
+                        "    tenant: ${TEST_TENANT}",
+                        "    secret: ${TEST_SECRET}",
+                        "    scopes:",
+                        "    - ${TEST_SCOPE}"
                     }).ToList();
                     break;
                 case CogniteHost.BlueField:

--- a/ExtractorUtils.Test/unit/ConfigurationTest.cs
+++ b/ExtractorUtils.Test/unit/ConfigurationTest.cs
@@ -7,6 +7,7 @@ using Cognite.Extractor.Logging;
 using Cognite.Extractor.Metrics;
 using Cognite.Extractor.Utils;
 using Cognite.Extractor.StateStorage;
+using Cognite.Extractor.Common;
 
 namespace ExtractorUtils.Test.Unit
 {

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Cognite.Extensions;
 using Cognite.Extractor.Configuration;
 using Cognite.Extractor.Logging;
 using Cognite.Extractor.Metrics;
@@ -139,87 +140,6 @@ namespace Cognite.Extractor.Utils
         /// </summary>
         /// <returns>String format</returns>
         public string Format { get; set; } = "CDF ({Message}): {HttpMethod} {Url} - {Elapsed} ms";
-    }
-
-    /// <summary>
-    /// Authenticator configuration. For more information, read the 
-    /// <see href="https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow">OAth 2.0 client credentials flow</see>
-    /// </summary>
-    public class AuthenticatorConfig
-    {
-        /// <summary>
-        /// Available authenticator implementations 
-        /// </summary>
-        public enum AuthenticatorImplementation
-        {
-            /// <summary>
-            /// Use Microsoft Authentication Library (MSAL). Recommended
-            /// </summary>
-            MSAL,
-            /// <summary>
-            /// Use a basic implementation. Post requests to the authority endpoint and parse the JSON response in case of success
-            /// </summary>
-            Basic
-        }
-
-        /// <summary>
-        /// Which implementation to use in the authenticator (optional)
-        /// </summary>
-        public AuthenticatorImplementation Implementation { get; set; } = AuthenticatorImplementation.MSAL;
-
-        /// <summary>
-        /// Identity provider authority endpoint (optional)
-        /// </summary>
-        /// <value>URI</value>
-        public string? Authority { get; set; } = "https://login.microsoftonline.com/";
-
-        /// <summary>
-        /// The application (client) Id
-        /// </summary>
-        /// <value>Client Id</value>
-        public string? ClientId { get; set; }
-
-        /// <summary>
-        /// The directory tenant. Either this or TokenUrl must be set.
-        /// </summary>
-        /// <value>Tenant</value>
-        public string? Tenant { get; set; }
-
-        /// <summary>
-        /// URL to fetch tokens from. Either this or Auhtority / Tenant must be set.
-        /// </summary>
-        /// <value>Tenant</value>
-        public string? TokenUrl { get; set; }
-
-        /// <summary>
-        /// The client secret
-        /// </summary>
-        /// <value>Secret</value>
-        public string? Secret { get; set; }
-
-        /// <summary>
-        /// Resource (optional, only valid for Basic implementation)
-        /// </summary>
-        /// <value>Secret</value>
-        public string? Resource { get; set; }
-
-        /// <summary>
-        /// Resource scopes
-        /// </summary>
-        /// <value>Scope</value>
-        public IList<string>? Scopes { get; set; }
-
-        /// <summary>
-        /// Audience
-        /// </summary>
-        /// <value>Audience</value>
-        public string? Audience { get; set; }
-
-        /// <summary>
-        /// Minimum time-to-live for the token in seconds (optional)
-        /// </summary>
-        /// <value>Minimum TTL</value>
-        public int MinTtl { get; set; } = 30;
     }
 
     /// <summary>

--- a/ExtractorUtils/Configuration/Configuration.cs
+++ b/ExtractorUtils/Configuration/Configuration.cs
@@ -5,6 +5,7 @@ using Cognite.Extractor.Metrics;
 using Cognite.Extractor.StateStorage;
 using Microsoft.Extensions.Logging;
 using System;
+using Cognite.Extractor.Common;
 
 namespace Cognite.Extractor.Utils
 {

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -1,4 +1,5 @@
-﻿using Cognite.Extractor.Configuration;
+﻿using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
 using Cognite.Extractor.Logging;
 using Cognite.Extractor.Metrics;
 using Microsoft.Extensions.DependencyInjection;

--- a/ExtractorUtils/ExtractorUtils.csproj
+++ b/ExtractorUtils/ExtractorUtils.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cognite.Config\Cognite.Configuration.csproj" />

--- a/docfx_project/tutorials/authentication.md
+++ b/docfx_project/tutorials/authentication.md
@@ -1,0 +1,16 @@
+# Using Cognite.Extensions for authentication
+
+Since the SDK has no built-in way to do OIDC authentication, it is sometimes convenient to have a library to do so. The utils handles this automatically when using the standard dependency injection method described elsewhere, but this means loading libraries for metrics, logging, configuration and local state. The Authenticator class is contained in the Cognite.Extensions library, and can be used with the SDK as follows:
+
+```c#
+using var client = new HttpClient();
+var auth = new Authenticator(new AuthenticatorConfig
+{
+	// Credentials added here
+}, client, null /* or logger, if you have one configured */);
+var cogniteClient = new Client.Builder()
+	.SetAppId("my-app")
+	.SetProject("my-project")            
+	.SetTokenProvider(auth.GetToken)
+	.Build();
+```

--- a/docfx_project/tutorials/toc.yml
+++ b/docfx_project/tutorials/toc.yml
@@ -19,3 +19,5 @@
   href: version.md
 - name: Running as service
   href: service.md
+- name: Simple OIDC
+  href: authentication.md


### PR DESCRIPTION
Make the authenticator available and usable from just the Cognite.Extensions library, to make it possible to use the utils for just authentication without pulling libraries for config, metrics, state, etc.

Also add documentation for how to do this.