### PR TITLE
Improve limiting by items per time unit

### DIFF
--- a/Cognite.Common/TaskThrottler.cs
+++ b/Cognite.Common/TaskThrottler.cs
@@ -70,6 +70,7 @@ namespace Cognite.Extractor.Common
         private readonly int _maxParallelism;
         private readonly int _maxPerUnit;
         private readonly TimeSpan _timeUnit;
+        private readonly TimeSpan _timeUnitChunk;
         // Default unederlying collection is a ConcurrentQueue
         private readonly BlockingCollection<Func<TaskResult>> _generators
             = new BlockingCollection<Func<TaskResult>>();
@@ -110,7 +111,17 @@ namespace Cognite.Extractor.Common
         {
             _maxParallelism = maxParallelism;
             _maxPerUnit = perUnit;
-            _timeUnit = timeUnit == null ? TimeSpan.Zero : TimeSpan.FromTicks(timeUnit.Value.Ticks);
+            if (timeUnit != null && perUnit > 0)
+            {
+                _timeUnit = TimeSpan.FromTicks(timeUnit.Value.Ticks);
+                _timeUnitChunk = TimeSpan.FromTicks(timeUnit.Value.Ticks / perUnit);
+            }
+            else
+            {
+                _timeUnit = TimeSpan.Zero;
+                _timeUnitChunk = TimeSpan.Zero;
+            }
+
             _quitOnFailure = quitOnFailure;
             _completionSource = CancellationTokenSource.CreateLinkedTokenSource(_source.Token);
             _keepAllResults = keepAllResults;
@@ -240,17 +251,21 @@ namespace Cognite.Extractor.Common
             lock (_lock)
             {
                 if (_maxParallelism > 0 && _runningTasks.Count >= _maxParallelism) return false;
-                if (_timeUnit > TimeSpan.Zero && _maxPerUnit > 0)
+                if (_timeUnit > TimeSpan.Zero)
                 {
                     var now = DateTime.UtcNow;
-                    var scheduledWithinLastTimeUnit = _results.Count(res => res.StartTime > now - _timeUnit);
+                    var scheduledInLastTimePeriod = _results.Count(res => res.StartTime > now - _timeUnit);
+                    var totalInLastChunk = _results.Count(res => res.StartTime > now - _timeUnitChunk);
 
-                    if (scheduledWithinLastTimeUnit > _maxPerUnit) return false;
+                    // Allow 2 in each "chunk" of time, as flex. This helps distribute tasks a bit more over time.
+                    if (totalInLastChunk > 1 || scheduledInLastTimePeriod >= _maxPerUnit) return false;
                 }
                 
             }
             return true;
         }
+
+        private DateTime _lastWaitTime;
 
         private async Task Run()
         {
@@ -281,7 +296,23 @@ namespace Cognite.Extractor.Common
                 {
                     if (_timeUnit > TimeSpan.Zero)
                     {
-                        WaitHandle.WaitAny(new[] { token.WaitHandle, _taskCompletionEvent }, _timeUnit);
+                        // If waiting is interrupted, we want to continue waiting, instead of restarting,
+                        // this helps ensure even distribution of tasks. I.e. if we run tasks that takes 200ms,
+                        // and use a time unit of 500ms, then we will wake up after 200ms, not schedule a new task,
+                        // wait another 500ms, then wake up again, so we effectively only wake up every 700ms,
+                        // This wake-up period should be a minimum value.
+                        TimeSpan waitTime = _timeUnitChunk;
+                        var now = DateTime.UtcNow;
+                        if (_lastWaitTime + _timeUnitChunk > now)
+                        {
+                            waitTime = _timeUnitChunk - (now - _lastWaitTime);
+                        }
+
+                        if (_lastWaitTime == DateTime.MinValue) _lastWaitTime = DateTime.UtcNow;
+
+                        var res = WaitHandle.WaitAny(new[] { token.WaitHandle, _taskCompletionEvent }, waitTime);
+
+                        if (res == WaitHandle.WaitTimeout) _lastWaitTime = DateTime.MinValue;
                     }
                     else
                     {

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -178,7 +178,7 @@ namespace ExtractorUtils.Test.Unit
                     var realMs = (end - start).TotalMilliseconds;
 
                     // Task overhead
-                    var flex = 100 + realMs * 0.1;
+                    var flex = 100 + realMs * 0.2;
                     Assert.True(realMs > minElapsedTime - flex && realMs < minElapsedTime + flex,
                         $"Execution took {realMs}ms but should be between {minElapsedTime - flex} and {minElapsedTime + flex}" +
                         $". Parallel: {minElapsedTimeParallel}, limit: {minElapsedTimeLimit}");

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -180,7 +180,8 @@ namespace ExtractorUtils.Test.Unit
                     // Task overhead
                     var flex = 100 + realMs * 0.1;
                     Assert.True(realMs > minElapsedTime - flex && realMs < minElapsedTime + flex,
-                        $"Execution took {realMs}ms but should be between {minElapsedTime - flex} and {minElapsedTime + flex}");
+                        $"Execution took {realMs}ms but should be between {minElapsedTime - flex} and {minElapsedTime + flex}" +
+                        $". Parallel: {minElapsedTimeParallel}, limit: {minElapsedTimeLimit}");
                     break;
                 }
                 catch (TrueException)


### PR DESCRIPTION
Slightly more clever implementation of this functionality, if we schedule 10 items per 1000 seconds, we really want to run one about every 100 seconds, not 10 in the first 10 seconds and 0 in the remaining time. This makes a few small changes to help with this.