### PR TITLE
[CDF-14262] Upsert logic

### DIFF
--- a/Cognite.Extensions/Assets/AssetUpdateSanitation.cs
+++ b/Cognite.Extensions/Assets/AssetUpdateSanitation.cs
@@ -40,6 +40,11 @@ namespace Cognite.Extensions
                     .Select(label => label.Truncate(ExternalIdMax))
                     .Take(10)
                     .ToList();
+                update.Labels.Set = update.Labels.Set?
+                    .Where(label => label != null && label.ExternalId != null)
+                    .Select(label => label.Truncate(ExternalIdMax))
+                    .Take(10)
+                    .ToList();
             }
         }
 
@@ -80,6 +85,9 @@ namespace Cognite.Extensions
             if (!update.ParentExternalId?.Set?.CheckLength(ExternalIdMax) ?? false) return ResourceType.ParentExternalId;
             if (update.Labels?.Add != null && (update.Labels.Add.Count() > AssetLabelsMax
                 || update.Labels.Add.Any(label => !label.ExternalId.CheckLength(ExternalIdMax))))
+                return ResourceType.Labels;
+            if (update.Labels?.Set != null && (update.Labels.Set.Count() > AssetLabelsMax
+                || update.Labels.Set.Any(label => !label.ExternalId.CheckLength(ExternalIdMax))))
                 return ResourceType.Labels;
 
             return null;

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -24,8 +24,8 @@
     <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CogniteSdk" Version="2.0.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.37.0" />
+    <PackageReference Include="CogniteSdk" Version="2.1.0" />
     <PackageReference Include="prometheus-net" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -235,6 +235,19 @@ namespace Cognite.Extensions
                 .Select(group => (group.Key, group.Select(pair => pair.err)))
                 .ToList();
         }
+
+        /// <summary>
+        /// Replace errors in this cognite result using <paramref name="replace"/>.
+        /// Used when the return type of a method is different from type of internal method
+        /// (like upsert).
+        /// </summary>
+        /// <typeparam name="TRep">New error type</typeparam>
+        /// <param name="replace">Method to replace error type</param>
+        /// <returns>Result with all errors replaced</returns>
+        public CogniteResult<TRep> Replace<TRep>(Func<TError, TRep> replace)
+        {
+            return new CogniteResult<TRep>(Errors?.Select(e => e.ReplaceSkipped(replace)));
+        }
     }
 
     /// <summary>
@@ -305,6 +318,19 @@ namespace Cognite.Extensions
             var res = new CogniteResult<TResult, TError>(errors, items);
             res.MergeErrors();
             return res;
+        }
+
+        /// <summary>
+        /// Replace errors in this cognite result using <paramref name="replace"/>.
+        /// Used when the return type of a method is different from type of internal method
+        /// (like upsert).
+        /// </summary>
+        /// <typeparam name="TRep">New error type</typeparam>
+        /// <param name="replace">Method to replace error type</param>
+        /// <returns>Result with all errors replaced</returns>
+        public new CogniteResult<TResult, TRep> Replace<TRep>(Func<TError, TRep> replace)
+        {
+            return new CogniteResult<TResult, TRep>(Errors?.Select(e => e.ReplaceSkipped(replace)), Results);
         }
     }
 
@@ -386,6 +412,28 @@ namespace Cognite.Extensions
             initial.Values = values;
 
             return initial;
+        }
+
+        /// <summary>
+        /// Return a new cognite error with error type replaced according to
+        /// <paramref name="replace"/>. Everything else will be the same.
+        /// </summary>
+        /// <typeparam name="TRep">Type of new element</typeparam>
+        /// <param name="replace">Method to replace old error type with new</param>
+        /// <returns>New cognite error with same contents except for replaced members of Skipped</returns>
+        public CogniteError<TRep> ReplaceSkipped<TRep>(Func<TError, TRep> replace)
+        {
+            return new CogniteError<TRep>
+            {
+                Complete = Complete,
+                Exception = Exception,
+                Message = Message,
+                Resource = Resource,
+                Skipped = Skipped?.Select(s => replace(s)),
+                Status = Status,
+                Type = Type,
+                Values = Values
+            };
         }
     }
 

--- a/Cognite.Extensions/TimeSeries/TimeSeriesExtensions.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesExtensions.cs
@@ -436,5 +436,91 @@ namespace Cognite.Extensions
 
             return new CogniteResult<TimeSeries, TimeSeriesUpdateItem>(errors, null);
         }
+
+        /// <summary>
+        /// Insert or update a list of timeseries, handling errors that come up during both insert and update.
+        /// Only timeseries that differ from timeseries in CDF are updated.
+        /// 
+        /// All given timeseries must have an external id, so it is not in practice possible to use this to change
+        /// the externalId of timeseries.
+        /// 
+        /// Timeseries are returned in the same order as given.
+        /// </summary>
+        /// <param name="tss">TimeSeries resource</param>
+        /// <param name="upserts">Assets to upsert</param>
+        /// <param name="chunkSize">Number of asset creates, retrieves or updates per request</param>
+        /// <param name="throttleSize">Maximum number of parallel requests</param>
+        /// <param name="retryMode">How to handle retries on errors</param>
+        /// <param name="sanitationMode">How to sanitize creates and updates</param>
+        /// <param name="options">How to update existing assets</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Result with failed creates/updates and list of assets</returns>
+        /// <exception cref="ArgumentException">All upserted assets must have external id</exception>
+        public static async Task<CogniteResult<TimeSeries, TimeSeriesCreate>> UpsertAsync(
+            this TimeSeriesResource tss,
+            IEnumerable<TimeSeriesCreate> upserts,
+            int chunkSize,
+            int throttleSize,
+            RetryMode retryMode,
+            SanitationMode sanitationMode,
+            UpsertParams? options,
+            CancellationToken token)
+        {
+            if (!upserts.All(a => a.ExternalId != null)) throw new ArgumentException("All inserts must have externalId");
+
+            var assetDict = upserts.ToDictionary(ts => ts.ExternalId);
+
+            var createResult = await tss.GetOrCreateTimeSeriesAsync(
+                assetDict.Keys,
+                keys => keys.Select(key => assetDict[key]),
+                chunkSize, throttleSize,
+                retryMode,
+                sanitationMode,
+                token).ConfigureAwait(false);
+
+            if (createResult.Errors?.Any() ?? false)
+            {
+                var badTimeSeries = new HashSet<TimeSeriesCreate>(createResult.Errors.Where(e => e.Skipped != null).SelectMany(e => e.Skipped));
+                assetDict = assetDict.Where(kvp => !badTimeSeries.Contains(kvp.Value)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            }
+
+            if (!assetDict.Any() || createResult.Results == null || !createResult.Results.Any()) return createResult;
+
+            var resultDict = createResult.Results.ToDictionary(ts => ts.ExternalId);
+            var updates = assetDict.Values
+                .Select(ts => (ts.ToUpdate(resultDict[ts.ExternalId], options)!, ts))
+                .Where(upd => upd.Item1 != null)
+                .ToDictionary(upd => upd.Item1.Id!.Value);
+
+            var updateResult = await tss.UpdateAsync(
+                updates.Values.Select(pair => pair.Item1),
+                chunkSize,
+                throttleSize,
+                retryMode,
+                sanitationMode,
+                token).ConfigureAwait(false);
+
+            var merged = updateResult.Replace(upd => updates[upd.Id!.Value].ts).Merge(createResult);
+
+            var resultTimeSeries = createResult.Results;
+
+            if (updateResult.Results != null && updateResult.Results.Any())
+            {
+                var updated = new HashSet<long>(updateResult.Results.Select(ts => ts.Id));
+                var finalResultDict = resultTimeSeries
+                    .Where(ts => !updated.Contains(ts.Id))
+                    .Union(updateResult.Results)
+                    .ToDictionary(ts => ts.ExternalId);
+
+                // To maintain the order as given we have to do this mapping if updates have been made.
+                resultTimeSeries = upserts
+                    .Where(ts => finalResultDict.ContainsKey(ts.ExternalId))
+                    .Select(ts => finalResultDict[ts.ExternalId])
+                    .ToList();
+                merged.Results = resultTimeSeries;
+            }
+
+            return merged;
+        }
     }
 }

--- a/Cognite.Extensions/TypeExtensions.cs
+++ b/Cognite.Extensions/TypeExtensions.cs
@@ -1,0 +1,191 @@
+﻿using CogniteSdk;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cognite.Extensions
+{
+    /// <summary>
+    /// Extensions to CogniteSdk types
+    /// </summary>
+    public static class TypeExtensions
+    {
+        private static bool AnyDiff<T>(IEnumerable<T>? newElems, IEnumerable<T>? oldElems, bool replace)
+        {
+            bool diff = true;
+            if (newElems != null && oldElems != null)
+            {
+                diff = newElems.Except(oldElems).Any()
+                    || replace && oldElems.Except(newElems).Any();
+            }
+            else if (newElems == null && !replace)
+            {
+                diff = false;
+            }
+
+            return diff;
+        }
+
+
+        private static UpdateLabels<IEnumerable<CogniteExternalId>>? GetLabelUpdate(
+            IEnumerable<CogniteExternalId>? newLabels,
+            IEnumerable<CogniteExternalId>? oldLabels,
+            bool replace)
+        {
+            bool labelDiff = AnyDiff(newLabels?.Select(l => l.ExternalId), oldLabels?.Select(l => l.ExternalId), replace);
+
+            if (!labelDiff) return null;
+
+            if (replace)
+            {
+                return new UpdateLabels<IEnumerable<CogniteExternalId>>
+                {
+                    Set = newLabels ?? Enumerable.Empty<CogniteExternalId>()
+                };
+            }
+            
+            return new UpdateLabels<IEnumerable<CogniteExternalId>>(newLabels ?? Enumerable.Empty<CogniteExternalId>());
+        }
+
+        private static UpdateDictionary<string>? GetMetadataUpdate(
+            Dictionary<string, string> newMeta,
+            Dictionary<string, string> oldMeta,
+            bool replace)
+        {
+            bool metaDiff = AnyDiff(newMeta, oldMeta, replace);
+
+            if (!metaDiff) return null;
+
+            if (replace)
+            {
+                return new UpdateDictionary<string>(newMeta ?? new Dictionary<string, string>());
+            }
+
+            return new UpdateDictionary<string>(newMeta ?? new Dictionary<string, string>(), Enumerable.Empty<string>());
+        }
+
+        /// <summary>
+        /// Build an update from the diff between <paramref name="asset"/> and <paramref name="old"/>,
+        /// where <paramref name="old"/> is retrieved from CDF.
+        /// </summary>
+        /// <param name="asset">New asset that could not be created during upsert</param>
+        /// <param name="old">Old asset retrieved from CDF</param>
+        /// <param name="opt">Options for how fields should be replaced</param>
+        /// <returns>Update item</returns>
+        /// <exception cref="ArgumentNullException">If asset or old are null</exception>
+        public static AssetUpdateItem? ToUpdate(this AssetCreate asset, Asset old, UpsertParams? opt)
+        {
+            if (asset == null) throw new ArgumentNullException(nameof(asset));
+            if (old == null) throw new ArgumentNullException(nameof(old));
+            if (opt == null) opt = new UpsertParams();
+
+            var upd = new AssetUpdate();
+
+            if (asset.DataSetId != old.DataSetId && (asset.DataSetId != null || opt.SetNull))
+                upd.DataSetId = new UpdateNullable<long?>(asset.DataSetId);
+            if (asset.Description != old.Description && (asset.Description != null || opt.SetNull))
+                upd.Description = new UpdateNullable<string?>(asset.Description);
+            if (asset.ExternalId != old.ExternalId && (asset.ExternalId != null || opt.SetNull))
+                upd.ExternalId = new UpdateNullable<string?>(asset.ExternalId);
+            upd.Labels = GetLabelUpdate(asset.Labels, old.Labels, opt.ReplaceLabels);
+            upd.Metadata = GetMetadataUpdate(asset.Metadata, old.Metadata, opt.ReplaceMetadata);
+
+            if (asset.Name != old.Name && asset.Name != null)
+                upd.Name = new Update<string>(asset.Name);
+            if (asset.ParentExternalId != old.ParentExternalId && asset.ParentExternalId != null)
+                upd.ParentExternalId = new Update<string?>(asset.ParentExternalId);
+            if (asset.ParentId != old.ParentId && asset.ParentId != null)
+                upd.ParentId = new Update<long?>(asset.ParentId);
+            if (asset.Source != old.Source && (asset.Source != null || opt.SetNull))
+                upd.Source = new UpdateNullable<string?>(asset.Source);
+
+
+            if (upd.DataSetId == null && upd.Description == null && upd.ExternalId == null
+                && upd.Labels == null && upd.Metadata == null && upd.Name == null
+                && upd.ParentExternalId == null && upd.ParentId == null && upd.Source == null) return null;
+
+            return new AssetUpdateItem(old.Id)
+            {
+                Update = upd
+            };
+        }
+
+
+        /// <summary>
+        /// Build an update from the diff between <paramref name="ts"/> and <paramref name="old"/>,
+        /// where <paramref name="old"/> is retrieved from CDF.
+        /// </summary>
+        /// <param name="ts">New timeseries that could not be created during upsert</param>
+        /// <param name="old">Old timeseries retrieved from CDF</param>
+        /// <param name="opt">Options for how fields should be replaced</param>
+        /// <returns>Update item</returns>
+        /// <exception cref="ArgumentNullException">If ts or old are null</exception>
+        public static TimeSeriesUpdateItem? ToUpdate(this TimeSeriesCreate ts, TimeSeries old, UpsertParams? opt)
+        {
+            if (ts == null) throw new ArgumentNullException(nameof(ts));
+            if (old == null) throw new ArgumentNullException(nameof(old));
+            if (opt == null) opt = new UpsertParams();
+
+            var upd = new TimeSeriesUpdate();
+
+            if (ts.AssetId != old.AssetId && (ts.AssetId != null || opt.SetNull))
+                upd.AssetId = new UpdateNullable<long?>(ts.AssetId);
+            if (ts.DataSetId != old.DataSetId && (ts.DataSetId != null || opt.SetNull))
+                upd.DataSetId = new UpdateNullable<long?>(ts.DataSetId);
+            if (ts.Description != old.Description && (ts.Description != null || opt.SetNull))
+                upd.Description = new UpdateNullable<string?>(ts.Description);
+            if (ts.ExternalId != old.ExternalId && (ts.ExternalId != null || opt.SetNull))
+                upd.ExternalId = new UpdateNullable<string?>(ts.ExternalId);
+
+            upd.Metadata = GetMetadataUpdate(ts.Metadata, old.Metadata, opt.ReplaceMetadata);
+
+            if (ts.Name != old.Name && (ts.Name != null || opt.SetNull))
+                upd.Name = new UpdateNullable<string?>(ts.Name);
+
+            bool secCatDiff = AnyDiff(ts.SecurityCategories, old.SecurityCategories, opt.ReplaceLabels);
+            if (secCatDiff)
+            {
+                upd.SecurityCategories = opt.ReplaceSecurityCategories
+                    ? new UpdateEnumerable<long?>(ts.SecurityCategories.Select(s => (long?)s) ?? Enumerable.Empty<long?>())
+                    : new UpdateEnumerable<long?>(ts.SecurityCategories.Select(s => (long?)s) ?? Enumerable.Empty<long?>(),
+                        Enumerable.Empty<long?>());
+            }
+
+            if (ts.Unit != old.Unit && (ts.Unit != null || opt.SetNull))
+                upd.Unit = new UpdateNullable<string?>(ts.Unit);
+
+            return new TimeSeriesUpdateItem(old.Id) { Update = upd };
+        }
+
+    }
+
+    /// <summary>
+    /// Settings for upsert
+    /// </summary>
+    public class UpsertParams
+    {
+        /// <summary>
+        /// Whether to use "Add" or "Set" when creating metadata.
+        /// If true, metadata is replaced entirely. Otherwise only the provided fields are replaced.
+        /// </summary>
+        public bool ReplaceMetadata { get; set; }
+
+        /// <summary>
+        /// Whether to use "Add" or "Set" when adding labels.
+        /// If true, labels are replaced entirely. Otherwise new labels are only added if they do not exist.
+        /// If true and no labels are provided, all are removed.
+        /// </summary>
+        public bool ReplaceLabels { get; set; }
+
+        /// <summary>
+        /// Whether to use "Add" or "Set" when 
+        /// </summary>
+        public bool ReplaceSecurityCategories { get; set; }
+        /// <summary>
+        /// Whether to set fields to null if they are not defined.
+        /// Default is true.
+        /// </summary>
+        public bool SetNull { get; set; } = true;
+    }
+}

--- a/Cognite.Extensions/TypeExtensions.cs
+++ b/Cognite.Extensions/TypeExtensions.cs
@@ -155,6 +155,10 @@ namespace Cognite.Extensions
             if (ts.Unit != old.Unit && (ts.Unit != null || opt.SetNull))
                 upd.Unit = new UpdateNullable<string?>(ts.Unit);
 
+            if (upd.AssetId == null && upd.DataSetId == null && upd.Description == null
+                && upd.ExternalId == null && upd.Metadata == null && upd.Name == null
+                && upd.SecurityCategories == null && upd.Unit == null) return null;
+
             return new TimeSeriesUpdateItem(old.Id) { Update = upd };
         }
 

--- a/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
@@ -811,5 +811,124 @@ namespace ExtractorUtils.Test.Integration
                 });
             }
         }
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestUpsert(bool replaceMeta)
+        {
+            using var tester = new CDFTester(CogniteHost.GreenField);
+
+            var upserts = Enumerable.Range(1, 5).Select(i => new TimeSeriesCreate
+            {
+                ExternalId = $"{tester.Prefix} test-upsert-{i}",
+                Name = $"test-upsert-{i}"
+            }).ToArray();
+
+            var options = new UpsertParams { ReplaceMetadata = replaceMeta, SetNull = true };
+
+            try
+            {
+                // Just create
+                var result1 = await tester.Destination.UpsertTimeSeriesAsync(upserts, RetryMode.OnError,
+                    SanitationMode.Remove, options, tester.Source.Token);
+                // Just retrieve
+                var result2 = await tester.Destination.UpsertTimeSeriesAsync(upserts, RetryMode.OnError,
+                    SanitationMode.Remove, options, tester.Source.Token);
+                // Update all
+                foreach (var ups in upserts)
+                {
+                    ups.Description = "Some description";
+                    ups.Metadata = new Dictionary<string, string>
+                    {
+                        { "someKey", "someValue" }
+                    };
+                }
+                var result3 = await tester.Destination.UpsertTimeSeriesAsync(upserts, RetryMode.OnError,
+                    SanitationMode.Remove, options, tester.Source.Token);
+                // Update all and add 2 more
+
+                foreach (var ups in upserts)
+                {
+                    ups.Metadata = new Dictionary<string, string>
+                    {
+                        { "someKey2", "someValue2" }
+                    };
+                }
+
+                upserts = upserts.Concat(Enumerable.Range(6, 2).Select(i => new TimeSeriesCreate
+                {
+                    ExternalId = $"{tester.Prefix} test-upsert-{i}",
+                    Name = $"test-upsert-{i}"
+                })).ToArray();
+
+                var result4 = await tester.Destination.UpsertTimeSeriesAsync(upserts, RetryMode.OnError,
+                    SanitationMode.Remove, options, tester.Source.Token);
+
+                // Update all, fail to create 2 more
+
+                foreach (var ups in upserts)
+                {
+                    ups.Unit = "Some unit";
+                }
+
+                upserts = upserts.Concat(Enumerable.Range(8, 2).Select(i => new TimeSeriesCreate
+                {
+                    ExternalId = $"{tester.Prefix} test-upsert-{i}",
+                    AssetId = 123
+                })).ToArray();
+
+                var result5 = await tester.Destination.UpsertTimeSeriesAsync(upserts, RetryMode.OnError,
+                    SanitationMode.Remove, options, tester.Source.Token);
+
+
+                Assert.Equal(5, result1.Results.Count());
+                result1.Throw();
+                Assert.Equal(5, result2.Results.Count());
+                result2.Throw();
+                Assert.Equal(5, result3.Results.Count());
+                result3.Throw();
+                Assert.All(result3.Results, res => {
+                    Assert.Single(res.Metadata);
+                    Assert.Equal("someValue", res.Metadata["someKey"]);
+                    Assert.Equal("Some description", res.Description);
+                });
+                Assert.Equal(7, result4.Results.Count());
+                result4.Throw();
+                Assert.All(result4.Results.Take(5), res => {
+                    if (replaceMeta)
+                    {
+                        Assert.Single(res.Metadata);
+                        Assert.Equal("someValue2", res.Metadata["someKey2"]);
+                    }
+                    else
+                    {
+                        Assert.Equal(2, res.Metadata.Count);
+                        Assert.Equal("someValue", res.Metadata["someKey"]);
+                        Assert.Equal("someValue2", res.Metadata["someKey2"]);
+                    }
+                });
+                Assert.Equal(7, result5.Results.Count());
+                Assert.Single(result5.Errors);
+                Assert.Equal(2, result5.Errors.First().Skipped.Count());
+                Assert.All(result5.Results, res => {
+                    Assert.Equal("Some unit", res.Unit);
+                });
+            }
+            finally
+            {
+                var ids = Enumerable.Range(1, 9)
+                    .Select(i => Identity.Create($"{tester.Prefix} test-upsert-{i}"))
+                    .ToList();
+                await tester.Destination.CogniteClient.TimeSeries.DeleteAsync(new TimeSeriesDelete
+                {
+                    IgnoreUnknownIds = true,
+                    Items = ids
+                });
+            }
+        }
+
+
     }
 }

--- a/ExtractorUtils/Cognite/CogniteDestination.cs
+++ b/ExtractorUtils/Cognite/CogniteDestination.cs
@@ -179,6 +179,40 @@ namespace Cognite.Extractor.Utils
                 token).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Insert or update a list of timeseries, handling errors that come up during both insert and update.
+        /// Only timeseries that differ from timeseries in CDF are updated.
+        /// 
+        /// All given timeseries must have an external id, so it is not in practice possible to use this to change
+        /// the externalId of timeseries.
+        /// 
+        /// Timeseries are returned in the same order as given.
+        /// </summary>
+        /// <param name="upserts">Assets to upsert</param>
+        /// <param name="retryMode">How to handle retries on errors</param>
+        /// <param name="sanitationMode">How to sanitize creates and updates</param>
+        /// <param name="options">How to update existing assets</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Result with failed creates/updates and list of assets</returns>
+        /// <exception cref="ArgumentException">All upserted assets must have external id</exception>
+        public async Task<CogniteResult<TimeSeries, TimeSeriesCreate>> UpsertTimeSeriesAsync(
+            IEnumerable<TimeSeriesCreate> upserts,
+            RetryMode retryMode,
+            SanitationMode sanitationMode,
+            UpsertParams? options,
+            CancellationToken token)
+        {
+            _logger.LogInformation("Upserting {Number} timseries in CDF", upserts.Count());
+            return await _client.TimeSeries.UpsertAsync(
+                upserts,
+                _config.CdfChunking.TimeSeries,
+                _config.CdfThrottling.TimeSeries,
+                retryMode,
+                sanitationMode,
+                options,
+                token).ConfigureAwait(false);
+        }
+
         #endregion
 
         #region assets

--- a/ExtractorUtils/Cognite/CogniteDestination.cs
+++ b/ExtractorUtils/Cognite/CogniteDestination.cs
@@ -303,6 +303,41 @@ namespace Cognite.Extractor.Utils
                 sanitationMode,
                 token).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Insert or update a list of assets, handling errors that come up during both insert and update.
+        /// Only assets that differ from assets in CDF are updated.
+        /// 
+        /// All given assets must have an external id, so it is not in practice possible to use this to change
+        /// the externalId of assets.
+        /// 
+        /// Assets are returned in the same order as given.
+        /// </summary>
+        /// <param name="upserts">Assets to upsert</param>
+        /// <param name="retryMode">How to handle retries on errors</param>
+        /// <param name="sanitationMode">How to sanitize creates and updates</param>
+        /// <param name="options">How to update existing assets</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Result with failed creates/updates and list of assets</returns>
+        /// <exception cref="ArgumentException">All upserted assets must have external id</exception>
+        public async Task<CogniteResult<Asset, AssetCreate>> UpsertAssetsAsync(
+            IEnumerable<AssetCreate> upserts,
+            RetryMode retryMode,
+            SanitationMode sanitationMode,
+            UpsertParams? options,
+            CancellationToken token)
+        {
+            _logger.LogInformation("Upserting {Number} assets in CDF", upserts.Count());
+            return await _client.Assets.UpsertAsync(
+                upserts,
+                _config.CdfChunking.Assets,
+                _config.CdfThrottling.Assets,
+                retryMode,
+                sanitationMode,
+                options,
+                token).ConfigureAwait(false);
+        }
+
         #endregion
 
         #region datapoints


### PR DESCRIPTION
With error handling on updates, we can implement upserts. The challenge is mostly just only processing updates for items which successfully were found or created.