### PR TITLE
[CDF-14308] Configuration to ignore SSL-certificate issues

### DIFF
--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -115,6 +115,11 @@ namespace Cognite.Extractor.Utils
         /// Configuration for automatically reporting extraction pipeline runs.
         /// </summary>
         public ExtractionRunConfig? ExtractionPipeline { get; set; }
+
+        /// <summary>
+        /// Configuration for handling SSL certificates.
+        /// </summary>
+        public CertificateConfig? Certificates { get; set; }
     }
 
     /// <summary>
@@ -288,6 +293,21 @@ namespace Cognite.Extractor.Utils
         /// If less than 0, there is no maximum.
         /// </summary>
         public int MaxDelay { get; set; } = 5_000;
+    }
+
+    /// <summary>
+    /// Configure options relating to SSL certificates.
+    /// </summary>
+    public class CertificateConfig
+    {
+        /// <summary>
+        /// True to accept all certificates. This must be considered a security risk in most circumstances.
+        /// </summary>
+        public bool AcceptAll { get; set; }
+        /// <summary>
+        /// List of certificate thumbprints to manually allow. This is much safer.
+        /// </summary>
+        public IEnumerable<string>? AllowList { get; set; }
     }
 
     #endregion

--- a/ExtractorUtils/config/config.example.yml
+++ b/ExtractorUtils/config/config.example.yml
@@ -115,6 +115,17 @@ cognite:
         # Frequency to report "Seen", in seconds. Less than or equal to zero will not report automatically.
         # frequency: 600
 
+    # Optional configuration for special handling of SSL certificates.
+    # This should never be considered a permanent solution to certificate problems.
+    certificates:
+        # True to accept all certificates.
+        # This poses a severe security risk.
+        accept-all: false
+        # List of thumbprints of certificates to allow.
+        # This is a smaller risk compared to accepting all certificates.
+        allow-list:
+            # - 99E92D8447AEF30483B1D7527812C9B7B3A915A7
+
 
 # Store state in a local database or in CDF raw to speed up starting, by not having to read state from destinations
 state-store:


### PR DESCRIPTION
I don't really like adding this, but this is a frequent issue with extractors, and there is no native way to work around it.

It is necessary to do this twice, since the best way to do it is only available on 2.1. Most users will be using a 2.1 compatible version, so this isn't a big problem. On 2.0 they need to call a method explicitly to use this.