### PR TITLE
Catch errors when retrieving in methods with error handling

### DIFF
--- a/Cognite.Extensions/Assets/AssetExtensions.cs
+++ b/Cognite.Extensions/Assets/AssetExtensions.cs
@@ -184,7 +184,16 @@ namespace Cognite.Extensions
             IEnumerable<Asset> found;
             using (CdfMetrics.Assets.WithLabels("retrieve").NewTimer())
             {
-                found = await assets.RetrieveAsync(externalIds.Select(Identity.Create), true, token).ConfigureAwait(false);
+                var idts = externalIds.Select(Identity.Create);
+                try
+                {
+                    found = await assets.RetrieveAsync(idts, true, token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    var err = ResultHandlers.ParseSimpleError<AssetCreate>(ex, idts, null);
+                    return new CogniteResult<Asset, AssetCreate>(new[] { err }, null);
+                }
             }
             _logger.LogDebug("Retrieved {Existing} assets from CDF", found.Count());
 
@@ -330,10 +339,6 @@ namespace Cognite.Extensions
             }
             return new CogniteResult<Asset, AssetCreate>(errors, null);
         }
-
-
-
-
 
         /// <summary>
         /// Attempt to update all assets in <paramref name="updates"/>, will retry

--- a/Cognite.Extensions/Assets/AssetResultHandlers.cs
+++ b/Cognite.Extensions/Assets/AssetResultHandlers.cs
@@ -100,6 +100,10 @@ namespace Cognite.Extensions
                 await CompleteError(resource, error, assets, assetChunkSize, assetThrottleSize, token).ConfigureAwait(false);
             }
 
+            // If we failed to complete the error
+            // TODO: Improve this
+            if (!error.Complete) return Enumerable.Empty<AssetCreate>();
+
             var items = new HashSet<Identity>(error.Values);
 
             var ret = new List<AssetCreate>();

--- a/Cognite.Extensions/Assets/AssetUpdateResultHandlers.cs
+++ b/Cognite.Extensions/Assets/AssetUpdateResultHandlers.cs
@@ -219,8 +219,19 @@ namespace Cognite.Extensions
                 }
             }
 
-            var assets = await resource.GetAssetsByIdsIgnoreErrors(assetsToFetch, assetChunkSize, assetThrottleSize, token)
-                .ConfigureAwait(false);
+            IEnumerable<Asset> assets;
+            try
+            {
+                assets = await resource
+                    .GetAssetsByIdsIgnoreErrors(assetsToFetch, assetChunkSize, assetThrottleSize, token)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                var err = ParseSimpleError(ex, assetsToFetch, items);
+                return new[] { err };
+            }
+            
             var byId = assets.ToDictionary(asset => asset.Id);
             var byExtId = assets.Where(asset => asset.ExternalId != null).ToDictionary(asset => asset.ExternalId);
 

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -35,6 +35,39 @@ namespace Cognite.Extensions
         }
 
         /// <summary>
+        /// Create a CogniteError from exception thrown when doing some simple operation to CDF.
+        /// Just creates a fatal error based on the exception.
+        /// </summary>
+        /// <typeparam name="TError">Errortype on result</typeparam>
+        /// <param name="ex">Exception thrown by method</param>
+        /// <param name="failed">Items that failed, optional</param>
+        /// <param name="skipped">Items that were skipped, optional</param>
+        /// <returns></returns>
+        public static CogniteError<TError> ParseSimpleError<TError>(
+            Exception ex,
+            IEnumerable<Identity>? failed,
+            IEnumerable<TError>? skipped)
+        {
+            if (ex == null) throw new ArgumentNullException(nameof(ex));
+
+            var err = new CogniteError<TError>
+            {
+                Message = ex.Message,
+                Exception = ex,
+                Type = ErrorType.FatalFailure,
+                Values = failed,
+                Skipped = skipped
+            };
+
+            if (ex is ResponseException rex)
+            {
+                err.Status = rex.Code;
+            }
+
+            return err;
+        }
+
+        /// <summary>
         /// Parse exception into CogniteError which describes the error in detail.
         /// </summary>
         /// <param name="ex">Exception to parse</param>

--- a/Cognite.Extensions/Events/EventExtensions.cs
+++ b/Cognite.Extensions/Events/EventExtensions.cs
@@ -188,7 +188,16 @@ namespace Cognite.Extensions
             IEnumerable<Event> found;
             using (CdfMetrics.Events.WithLabels("retrieve").NewTimer())
             {
-                found = await resource.RetrieveAsync(externalIds.Select(Identity.Create), true, token).ConfigureAwait(false);
+                var idts = externalIds.Select(Identity.Create);
+                try
+                {
+                    found = await resource.RetrieveAsync(idts, true, token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    var err = ResultHandlers.ParseSimpleError<EventCreate>(ex, idts, null);
+                    return new CogniteResult<Event, EventCreate>(new[] { err }, null);
+                }
             }
             _logger.LogDebug("Retrieved {Existing} events from CDF", found.Count());
 

--- a/Cognite.Extensions/Sequences/SequenceExtensions.cs
+++ b/Cognite.Extensions/Sequences/SequenceExtensions.cs
@@ -235,7 +235,16 @@ namespace Cognite.Extensions
             IEnumerable<Sequence> found;
             using (CdfMetrics.Sequences.WithLabels("retrieve").NewTimer())
             {
-                found = await client.RetrieveAsync(externalIds.Select(id => new Identity(id)), true, token).ConfigureAwait(false);
+                var idts = externalIds.Select(id => new Identity(id));
+                try
+                {
+                    found = await client.RetrieveAsync(idts, true, token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    var err = ResultHandlers.ParseSimpleError<SequenceCreate>(ex, idts, null);
+                    return new CogniteResult<Sequence, SequenceCreate>(new[] { err }, null);
+                }
             }
             _logger.LogDebug("Retrieved {Existing} sequences from CDF", found.Count());
 

--- a/Cognite.Extensions/TimeSeries/TimeSeriesExtensions.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesExtensions.cs
@@ -234,7 +234,16 @@ namespace Cognite.Extensions
             IEnumerable<TimeSeries> found;
             using (CdfMetrics.TimeSeries.WithLabels("retrieve").NewTimer())
             {
-                found = await client.RetrieveAsync(externalIds.Select(id => new Identity(id)), true, token).ConfigureAwait(false);
+                var idts = externalIds.Select(id => new Identity(id));
+                try
+                {
+                    found = await client.RetrieveAsync(idts, true, token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    var err = ResultHandlers.ParseSimpleError<TimeSeriesCreate>(ex, idts, null);
+                    return new CogniteResult<TimeSeries, TimeSeriesCreate>(new[] { err }, null);
+                }
             }
             _logger.LogDebug("Retrieved {Existing} times series from CDF", found.Count());
 


### PR DESCRIPTION
We shouldn't really throw exceptions from these, as we expect them to return error objects. We still treat these errors as fatal.