### PR TITLE
Common handlers

### DIFF
--- a/Cognite.Extensions/Assets/AssetResultHandlers.cs
+++ b/Cognite.Extensions/Assets/AssetResultHandlers.cs
@@ -64,11 +64,11 @@ namespace Cognite.Extensions
         {
             return error.Resource switch
             {
-                ResourceType.DataSetId => asset.DataSetId.HasValue && badValues.Contains(Identity.Create(asset.DataSetId.Value)),
-                ResourceType.ExternalId => asset.ExternalId != null && badValues.Contains(Identity.Create(asset.ExternalId)),
-                ResourceType.ParentExternalId => asset.ParentExternalId != null && badValues.Contains(Identity.Create(asset.ParentExternalId)),
-                ResourceType.ParentId => asset.ParentId.HasValue && badValues.Contains(Identity.Create(asset.ParentId.Value)),
-                ResourceType.Labels => asset.Labels != null && asset.Labels.Any(l => badValues.Contains(Identity.Create(l.ExternalId))),
+                ResourceType.DataSetId => badValues.ContainsIdentity(asset.DataSetId),
+                ResourceType.ExternalId => badValues.ContainsIdentity(asset.ExternalId),
+                ResourceType.ParentExternalId => badValues.ContainsIdentity(asset.ParentExternalId),
+                ResourceType.ParentId => badValues.ContainsIdentity(asset.ParentId),
+                ResourceType.Labels => asset.Labels != null && asset.Labels.Any(l => badValues.ContainsIdentity(l.ExternalId)),
                 _ => false
             };
         }

--- a/Cognite.Extensions/Assets/AssetSanitation.cs
+++ b/Cognite.Extensions/Assets/AssetSanitation.cs
@@ -98,7 +98,8 @@ namespace Cognite.Extensions
 
         private static readonly DistinctResource<AssetCreate>[] assetDistinct = new[]
         {
-            new DistinctResource<AssetCreate>("Duplicate external ids", ResourceType.ExternalId, a => Identity.Create(a.ExternalId))
+            new DistinctResource<AssetCreate>("Duplicate external ids", ResourceType.ExternalId,
+                a => a != null ? Identity.Create(a.ExternalId) : null)
         };
 
 

--- a/Cognite.Extensions/Assets/AssetSanitation.cs
+++ b/Cognite.Extensions/Assets/AssetSanitation.cs
@@ -95,6 +95,13 @@ namespace Cognite.Extensions
             return null;
         }
 
+
+        private static readonly DistinctResource<AssetCreate>[] assetDistinct = new[]
+        {
+            new DistinctResource<AssetCreate>("Duplicate external ids", ResourceType.ExternalId, a => Identity.Create(a.ExternalId))
+        };
+
+
         /// <summary>
         /// Clean list of AssetCreate objects, sanitizing each and removing any duplicates.
         /// The first encountered duplicate is kept.
@@ -106,75 +113,7 @@ namespace Cognite.Extensions
             IEnumerable<AssetCreate> assets,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (assets, Enumerable.Empty<CogniteError<AssetCreate>>());
-            if (assets == null)
-            {
-                throw new ArgumentNullException(nameof(assets));
-            }
-            var result = new List<AssetCreate>();
-            var errors = new List<CogniteError<AssetCreate>>();
-
-            var ids = new HashSet<string>();
-            var duplicated = new HashSet<string>();
-            var bad = new List<(ResourceType, AssetCreate)>();
-
-            foreach (var asset in assets)
-            {
-                bool toAdd = true;
-                if (mode == SanitationMode.Remove)
-                {
-                    var failedField = asset.Verify();
-                    if (failedField.HasValue)
-                    {
-                        bad.Add((failedField.Value, asset));
-                        toAdd = false;
-                    }
-                }
-                else if (mode == SanitationMode.Clean)
-                {
-                    asset.Sanitize();
-                    if (asset.Name == null)
-                    {
-                        bad.Add((ResourceType.Name, asset));
-                        toAdd = false;
-                    }
-                }
-                if (asset.ExternalId != null)
-                {
-                    if (!ids.Add(asset.ExternalId))
-                    {
-                        duplicated.Add(asset.ExternalId);
-                        toAdd = false;
-                    }
-                }
-
-                if (toAdd)
-                {
-                    result.Add(asset);
-                }
-            }
-            if (duplicated.Any())
-            {
-                errors.Add(new CogniteError<AssetCreate>
-                {
-                    Status = 409,
-                    Message = "Duplicate external ids",
-                    Resource = ResourceType.ExternalId,
-                    Type = ErrorType.ItemDuplicated,
-                    Values = duplicated.Select(item => Identity.Create(item)).ToArray()
-                });
-            }
-            if (bad.Any())
-            {
-                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError<AssetCreate>
-                {
-                    Skipped = group.Select(pair => pair.Item2).ToList(),
-                    Resource = group.Key,
-                    Type = ErrorType.SanitationFailed,
-                    Status = 400
-                }));
-            }
-            return (result, errors);
+            return CleanRequest(assetDistinct, assets, Verify, Sanitize, mode);
         }
     }
 }

--- a/Cognite.Extensions/Assets/AssetUpdateResultHandlers.cs
+++ b/Cognite.Extensions/Assets/AssetUpdateResultHandlers.cs
@@ -71,6 +71,42 @@ namespace Cognite.Extensions
             }
         }
 
+        private static bool IsAffected(AssetUpdateItem item, HashSet<Identity> badValues, CogniteError<AssetUpdateItem> error)
+        {
+            var update = item.Update;
+            switch (error.Resource)
+            {
+                case ResourceType.Id:
+                    return item.Id.HasValue && badValues.Contains(Identity.Create(item.Id.Value));
+                case ResourceType.DataSetId:
+                    return update.DataSetId?.Set != null && badValues.Contains(Identity.Create(update.DataSetId.Set.Value));
+                case ResourceType.ExternalId:
+                    if (error.Type == ErrorType.ItemMissing)
+                    {
+                        return update.ExternalId?.Set != null && badValues.Contains(Identity.Create(update.ExternalId.Set))
+                            || item.ExternalId != null && badValues.Contains(Identity.Create(item.ExternalId))
+                            || update.ParentExternalId?.Set != null && badValues.Contains(Identity.Create(update.ParentExternalId.Set));
+                    }
+                    else if (error.Type == ErrorType.ItemExists)
+                    {
+                        return update.ExternalId?.Set != null && badValues.Contains(Identity.Create(update.ExternalId.Set));
+                    }
+                    break;
+                case ResourceType.ParentId:
+                    if (error.Type == ErrorType.IllegalItem)
+                    {
+                        return badValues.Contains(item);
+                    }
+                    return update.ParentId?.Set != null && badValues.Contains(Identity.Create(update.ParentId.Set.Value))
+                            || update.ParentExternalId?.Set != null && badValues.Contains(Identity.Create(update.ParentExternalId.Set));
+                case ResourceType.Labels:
+                    var labels = update.Labels?.Add ?? update.Labels?.Set;
+                    return labels != null && labels.Any(l => badValues.Contains(Identity.Create(l.ExternalId)));
+            }
+            return false;
+        }
+
+
         /// <summary>
         /// Clean list of AssetCreate objects based on CogniteError object
         /// </summary>
@@ -81,95 +117,7 @@ namespace Cognite.Extensions
             CogniteError<AssetUpdateItem> error,
             IEnumerable<AssetUpdateItem> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
-            if (error == null)
-            {
-                return items;
-            }
-
-            if (!error.Values?.Any() ?? true)
-            {
-                error.Values = items.Select(update => update.ExternalId != null
-                    ? Identity.Create(update.ExternalId)
-                    : Identity.Create(update.Id!.Value));
-                return Array.Empty<AssetUpdateItem>();
-            }
-
-            var badValues = new HashSet<Identity>(error.Values);
-
-            var ret = new List<AssetUpdateItem>();
-            var skipped = new List<AssetUpdateItem>();
-
-            foreach (var item in items)
-            {
-                bool added = false;
-                var update = item.Update;
-
-                switch (error.Resource)
-                {
-                    case ResourceType.Id:
-                        if (!item.Id.HasValue || !badValues.Contains(Identity.Create(item.Id.Value))) added = true;
-                        break;
-                    case ResourceType.DataSetId:
-                        if (update.DataSetId?.Set == null || !badValues.Contains(Identity.Create(update.DataSetId.Set.Value))) added = true;
-                        break;
-                    case ResourceType.ExternalId:
-                        if (error.Type == ErrorType.ItemMissing)
-                        {
-                            if ((update.ExternalId?.Set == null || !badValues.Contains(Identity.Create(update.ExternalId.Set)))
-                                && (item.ExternalId == null || !badValues.Contains(Identity.Create(item.ExternalId)))
-                                && (update.ParentExternalId?.Set == null || !badValues.Contains(Identity.Create(update.ParentExternalId.Set))))
-                                    added = true;
-                        }
-                        else if (error.Type == ErrorType.ItemExists)
-                        {
-                            if (update.ExternalId?.Set == null || !badValues.Contains(Identity.Create(update.ExternalId.Set)))
-                                added = true;
-                        }
-                        break;
-                    case ResourceType.ParentId:
-                        if (error.Type == ErrorType.IllegalItem)
-                        {
-                            if ((item.ExternalId == null || !badValues.Contains(Identity.Create(item.ExternalId)))
-                                && (item.Id == null || !badValues.Contains(Identity.Create(item.Id.Value)))) added = true;
-                        }
-                        else
-                        {
-                            if ((update.ParentId?.Set == null || !badValues.Contains(Identity.Create(update.ParentId.Set.Value)))
-                            && (update.ParentExternalId?.Set == null || !badValues.Contains(Identity.Create(update.ParentExternalId.Set))))
-                                added = true;
-                        }
-                        break;
-                    case ResourceType.Labels:
-                        if (update.Labels?.Add == null
-                            || !update.Labels.Add.Any(label => badValues.Contains(Identity.Create(label.ExternalId)))) added = true;
-                        break;
-                }
-
-                if (added)
-                {
-                    ret.Add(item);
-                }
-                else
-                {
-                    CdfMetrics.AssetUpdatesSkipped.Inc();
-                    skipped.Add(item);
-                }
-            }
-
-            if (skipped.Any())
-            {
-                error.Skipped = skipped;
-            }
-            else
-            {
-                error.Skipped = skipped;
-                return Array.Empty<AssetUpdateItem>();
-            }
-            return ret;
+            return CleanFromErrorCommon(error, items, IsAffected, item => item, CdfMetrics.TimeSeriesUpdatesSkipped);
         }
 
         /// <summary>

--- a/Cognite.Extensions/Assets/AssetUpdateResultHandlers.cs
+++ b/Cognite.Extensions/Assets/AssetUpdateResultHandlers.cs
@@ -77,19 +77,19 @@ namespace Cognite.Extensions
             switch (error.Resource)
             {
                 case ResourceType.Id:
-                    return item.Id.HasValue && badValues.Contains(Identity.Create(item.Id.Value));
+                    return badValues.ContainsIdentity(item.Id);
                 case ResourceType.DataSetId:
-                    return update.DataSetId?.Set != null && badValues.Contains(Identity.Create(update.DataSetId.Set.Value));
+                    return badValues.ContainsIdentity(update.DataSetId?.Set);
                 case ResourceType.ExternalId:
                     if (error.Type == ErrorType.ItemMissing)
                     {
-                        return update.ExternalId?.Set != null && badValues.Contains(Identity.Create(update.ExternalId.Set))
-                            || item.ExternalId != null && badValues.Contains(Identity.Create(item.ExternalId))
-                            || update.ParentExternalId?.Set != null && badValues.Contains(Identity.Create(update.ParentExternalId.Set));
+                        return badValues.ContainsIdentity(update.ExternalId?.Set)
+                            || badValues.ContainsIdentity(item.ExternalId)
+                            || badValues.ContainsIdentity(update.ParentExternalId?.Set);
                     }
                     else if (error.Type == ErrorType.ItemExists)
                     {
-                        return update.ExternalId?.Set != null && badValues.Contains(Identity.Create(update.ExternalId.Set));
+                        return badValues.ContainsIdentity(update.ExternalId?.Set);
                     }
                     break;
                 case ResourceType.ParentId:
@@ -97,11 +97,11 @@ namespace Cognite.Extensions
                     {
                         return badValues.Contains(item);
                     }
-                    return update.ParentId?.Set != null && badValues.Contains(Identity.Create(update.ParentId.Set.Value))
-                            || update.ParentExternalId?.Set != null && badValues.Contains(Identity.Create(update.ParentExternalId.Set));
+                    return badValues.ContainsIdentity(update.ParentId?.Set)
+                        || badValues.ContainsIdentity(update.ParentExternalId?.Set);
                 case ResourceType.Labels:
                     var labels = update.Labels?.Add ?? update.Labels?.Set;
-                    return labels != null && labels.Any(l => badValues.Contains(Identity.Create(l.ExternalId)));
+                    return labels != null && labels.Any(l => badValues.ContainsIdentity(l.ExternalId));
             }
             return false;
         }

--- a/Cognite.Extensions/CdfMetrics.cs
+++ b/Cognite.Extensions/CdfMetrics.cs
@@ -38,5 +38,7 @@ namespace Cognite.Extensions
 
         public static Counter AssetUpdatesSkipped { get; } = Metrics.CreateCounter("extractor_utils_cdf_asset_updates_skipped",
             "Number of asset updates skipped due to errors");
+        public static Counter TimeSeriesUpdatesSkipped { get; } = Metrics.CreateCounter("extractor_utils_cdf_timeseries_updates_skipped",
+            "Number of timeseries updates skipped due to errors");
     }
 }

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -142,6 +142,30 @@ namespace Cognite.Extensions
             }
             return ret;
         }
+
+        /// <summary>
+        /// Utility method for checking if set of identities contains external id.
+        /// </summary>
+        /// <param name="set">Set of identities</param>
+        /// <param name="idt">ExternalId to test</param>
+        /// <returns>True if externalId is non-null and set contains it, false otherwise</returns>
+        public static bool ContainsIdentity(this HashSet<Identity> set, string? idt)
+        {
+            if (idt == null) return false;
+            return set.Contains(Identity.Create(idt));
+        }
+
+        /// <summary>
+        /// Utility method for checking if set of identities contains internal id.
+        /// </summary>
+        /// <param name="set">Set of identities</param>
+        /// <param name="idt">ExternalId to test</param>
+        /// <returns>True if internal id is non-null and set contains it, false otherwise</returns>
+        public static bool ContainsIdentity(this HashSet<Identity> set, long? idt)
+        {
+            if (idt == null) return false;
+            return set.Contains(Identity.Create(idt.Value));
+        }
     }
 
 

--- a/Cognite.Extensions/Events/EventResultHandlers.cs
+++ b/Cognite.Extensions/Events/EventResultHandlers.cs
@@ -46,9 +46,9 @@ namespace Cognite.Extensions
         {
             return error.Resource switch
             {
-                ResourceType.DataSetId => evt.DataSetId.HasValue && badValues.Contains(Identity.Create(evt.DataSetId.Value)),
-                ResourceType.ExternalId => evt.ExternalId != null && badValues.Contains(Identity.Create(evt.ExternalId)),
-                ResourceType.AssetId => evt.AssetIds != null && evt.AssetIds.Any(id => badValues.Contains(Identity.Create(id))),
+                ResourceType.DataSetId => badValues.ContainsIdentity(evt.DataSetId),
+                ResourceType.ExternalId => badValues.ContainsIdentity(evt.ExternalId),
+                ResourceType.AssetId => evt.AssetIds != null && evt.AssetIds.Any(id => badValues.ContainsIdentity(id)),
                 _ => false
             };
         }

--- a/Cognite.Extensions/Events/EventSanitation.cs
+++ b/Cognite.Extensions/Events/EventSanitation.cs
@@ -97,7 +97,8 @@ namespace Cognite.Extensions
 
         private static readonly DistinctResource<EventCreate>[] eventDistinct = new[]
         {
-            new DistinctResource<EventCreate>("Duplicate external ids", ResourceType.ExternalId, e => Identity.Create(e.ExternalId))
+            new DistinctResource<EventCreate>("Duplicate external ids", ResourceType.ExternalId,
+                e => e != null ? Identity.Create(e.ExternalId) : null)
         };
 
         /// <summary>

--- a/Cognite.Extensions/Sanitation.cs
+++ b/Cognite.Extensions/Sanitation.cs
@@ -256,8 +256,8 @@ namespace Cognite.Extensions
             Action<T> sanitize,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (items.ToList(), new List<CogniteError<T>>());
             if (items == null) throw new ArgumentNullException(nameof(items));
+            if (mode == SanitationMode.None) return (items.ToList(), new List<CogniteError<T>>());
 
             var result = new List<T>();
             var errors = new List<CogniteError<T>>();

--- a/Cognite.Extensions/Sanitation.cs
+++ b/Cognite.Extensions/Sanitation.cs
@@ -237,7 +237,7 @@ namespace Cognite.Extensions
 
         private class DistinctResource<T>
         {
-            public DistinctResource(string text, ResourceType resource, Func<T, Identity> selector)
+            public DistinctResource(string text, ResourceType resource, Func<T, Identity?> selector)
             {
                 Text = text;
                 Resource = resource;
@@ -246,7 +246,7 @@ namespace Cognite.Extensions
 
             public string Text { get; }
             public ResourceType Resource { get; }
-            public Func<T, Identity> Selector { get; }
+            public Func<T, Identity?> Selector { get; }
         }
 
         private static (List<T>, List<CogniteError<T>>) CleanRequest<T>(

--- a/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
+++ b/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
@@ -53,9 +53,9 @@ namespace Cognite.Extensions
         {
             return error.Resource switch
             {
-                ResourceType.DataSetId => seq.DataSetId.HasValue && badValues.Contains(Identity.Create(seq.DataSetId.Value)),
-                ResourceType.ExternalId => seq.ExternalId != null && badValues.Contains(Identity.Create(seq.ExternalId)),
-                ResourceType.AssetId => seq.AssetId.HasValue && badValues.Contains(Identity.Create(seq.AssetId.Value)),
+                ResourceType.DataSetId => badValues.ContainsIdentity(seq.DataSetId),
+                ResourceType.ExternalId => badValues.ContainsIdentity(seq.ExternalId),
+                ResourceType.AssetId => badValues.ContainsIdentity(seq.AssetId),
                 _ => false
             };
         }

--- a/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
+++ b/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
@@ -49,6 +49,17 @@ namespace Cognite.Extensions
             }
         }
 
+        private static bool IsAffected(SequenceCreate seq, HashSet<Identity> badValues, CogniteError<SequenceCreate> error)
+        {
+            return error.Resource switch
+            {
+                ResourceType.DataSetId => seq.DataSetId.HasValue && badValues.Contains(Identity.Create(seq.DataSetId.Value)),
+                ResourceType.ExternalId => seq.ExternalId != null && badValues.Contains(Identity.Create(seq.ExternalId)),
+                ResourceType.AssetId => seq.AssetId.HasValue && badValues.Contains(Identity.Create(seq.AssetId.Value)),
+                _ => false
+            };
+        }
+
         /// <summary>
         /// Clean list of SequenceCreate objects based on CogniteError
         /// </summary>
@@ -56,57 +67,12 @@ namespace Cognite.Extensions
         /// <param name="sequences">Sequences to clean</param>
         /// <returns>Sequences that are not affected by the error</returns>
         public static IEnumerable<SequenceCreate> CleanFromError(
-            CogniteError<SequenceCreate> error,
-            IEnumerable<SequenceCreate> sequences)
+        CogniteError<SequenceCreate> error,
+        IEnumerable<SequenceCreate> sequences)
         {
-            if (sequences == null) throw new ArgumentNullException(nameof(sequences));
-            if (error == null) return sequences;
-            if (!error.Values?.Any() ?? true)
-            {
-                error.Values = sequences.Where(seq => seq.ExternalId != null).Select(seq => Identity.Create(seq.ExternalId));
-                return Enumerable.Empty<SequenceCreate>();
-            }
-
-            var items = new HashSet<Identity>(error.Values);
-
-            var ret = new List<SequenceCreate>();
-            var skipped = new List<SequenceCreate>();
-
-            foreach (var seq in sequences)
-            {
-                bool added = false;
-                switch (error.Resource)
-                {
-                    case ResourceType.DataSetId:
-                        if (!seq.DataSetId.HasValue || !items.Contains(Identity.Create(seq.DataSetId.Value))) added = true;
-                        break;
-                    case ResourceType.ExternalId:
-                        if (seq.ExternalId == null || !items.Contains(Identity.Create(seq.ExternalId))) added = true;
-                        break;
-                    case ResourceType.AssetId:
-                        if (!seq.AssetId.HasValue || !items.Contains(Identity.Create(seq.AssetId.Value))) added = true;
-                        break;
-                }
-                if (added)
-                {
-                    ret.Add(seq);
-                }
-                else
-                {
-                    CdfMetrics.SequencesSkipped.Inc();
-                    skipped.Add(seq);
-                }
-            }
-            if (skipped.Any())
-            {
-                error.Skipped = skipped;
-            }
-            else
-            {
-                error.Skipped = sequences;
-                return Enumerable.Empty<SequenceCreate>();
-            }
-            return ret;
+            return CleanFromErrorCommon(error, sequences, IsAffected,
+                seq => seq.ExternalId == null ? null : Identity.Create(seq.ExternalId),
+                CdfMetrics.SequencesSkipped);
         }
 
         private static void ParseSequenceRowException(ResponseException ex, CogniteError err)

--- a/Cognite.Extensions/Sequences/SequenceSanitation.cs
+++ b/Cognite.Extensions/Sequences/SequenceSanitation.cs
@@ -69,15 +69,18 @@ namespace Cognite.Extensions
             seq.Metadata = seq.Metadata.SanitizeMetadata(SequenceMetadataMaxPerKey, SequenceMetadataMaxBytes,
                 SequenceMetadataMaxBytes, SequenceMetadataMaxBytes, out int totalBytes);
 
-            foreach (var col in seq.Columns)
+            if (seq.Columns != null)
             {
-                col.ExternalId = col.ExternalId.Truncate(ExternalIdMax);
-                col.Name = col.Name.Truncate(SequenceColumnNameMax);
-                col.Description = col.Description.Truncate(SequenceColumnDescriptionMax);
-                col.Metadata = col.Metadata.SanitizeMetadata(SequenceColumnMetadataMaxPerKey, SequenceColumnMetadataMaxBytes,
-                    SequenceColumnMetadataMaxBytes,
-                    Math.Min(SequenceColumnMetadataMaxBytes, SequenceMetadataMaxBytesTotal - totalBytes), out int colBytes);
-                totalBytes += colBytes;
+                foreach (var col in seq.Columns)
+                {
+                    col.ExternalId = col.ExternalId.Truncate(ExternalIdMax);
+                    col.Name = col.Name.Truncate(SequenceColumnNameMax);
+                    col.Description = col.Description.Truncate(SequenceColumnDescriptionMax);
+                    col.Metadata = col.Metadata.SanitizeMetadata(SequenceColumnMetadataMaxPerKey, SequenceColumnMetadataMaxBytes,
+                        SequenceColumnMetadataMaxBytes,
+                        Math.Min(SequenceColumnMetadataMaxBytes, SequenceMetadataMaxBytesTotal - totalBytes), out int colBytes);
+                    totalBytes += colBytes;
+                }
             }
         }
 
@@ -216,7 +219,8 @@ namespace Cognite.Extensions
 
         private static readonly DistinctResource<SequenceCreate>[] sequenceDistinct = new[]
         {
-            new DistinctResource<SequenceCreate>("Duplicate external ids", ResourceType.ExternalId, s => Identity.Create(s.ExternalId))
+            new DistinctResource<SequenceCreate>("Duplicate external ids", ResourceType.ExternalId,
+                s => s.ExternalId != null ? Identity.Create(s.ExternalId) : null)
         };
 
         /// <summary>

--- a/Cognite.Extensions/Sequences/SequenceSanitation.cs
+++ b/Cognite.Extensions/Sequences/SequenceSanitation.cs
@@ -213,6 +213,12 @@ namespace Cognite.Extensions
             return null;
         }
 
+
+        private static readonly DistinctResource<SequenceCreate>[] sequenceDistinct = new[]
+        {
+            new DistinctResource<SequenceCreate>("Duplicate external ids", ResourceType.ExternalId, s => Identity.Create(s.ExternalId))
+        };
+
         /// <summary>
         /// Clean list of SequenceCreate objects, sanitizing each and removing any duplicates.
         /// The first encountered duplicate is kept.
@@ -225,78 +231,29 @@ namespace Cognite.Extensions
             IEnumerable<SequenceCreate> sequences,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (sequences, Enumerable.Empty<CogniteError<SequenceCreate>>());
-            if (sequences == null) throw new ArgumentNullException(nameof(sequences));
+            var (result, errors) = CleanRequest(sequenceDistinct, sequences, Verify, Sanitize, mode);
 
-            var result = new List<SequenceCreate>();
-            var errors = new List<CogniteError<SequenceCreate>>();
+            if (mode == SanitationMode.None) return (result, errors);
 
-            var ids = new HashSet<string>();
-            var duplicated = new HashSet<string>();
-            var bad = new List<(ResourceType, SequenceCreate)>();
             var withDupColumns = new List<SequenceCreate>();
 
-            foreach (var seq in sequences)
+            foreach (var seq in result)
             {
                 var columns = new HashSet<string>();
-                bool toAdd = true;
-                if (mode == SanitationMode.Remove)
-                {
-                    var failedField = seq.Verify();
-                    if (failedField.HasValue)
-                    {
-                        bad.Add((failedField.Value, seq));
-                        toAdd = false;
-                    }
-                }
-                else if (mode == SanitationMode.Clean)
-                {
-                    if (seq.Columns == null || !seq.Columns.Any())
-                    {
-                        bad.Add((ResourceType.SequenceColumns, seq));
-                        toAdd = false;
-                    }
-                    else
-                    {
-                        seq.Sanitize();
-                    }
-                }
 
-                if (seq.ExternalId != null)
+                foreach (var col in seq.Columns)
                 {
-                    if (!ids.Add(seq.ExternalId))
+                    if (!columns.Add(col.ExternalId))
                     {
-                        duplicated.Add(seq.ExternalId);
-                        toAdd = false;
+                        withDupColumns.Add(seq);
+                        break;
                     }
-                }
-
-                if (seq.Columns != null)
-                {
-                    foreach (var col in seq.Columns)
-                    {
-                        if (col.ExternalId == null)
-                        {
-                            bad.Add((ResourceType.ColumnExternalId, seq));
-                            break;
-                        }
-                        if (!columns.Add(col.ExternalId))
-                        {
-                            withDupColumns.Add(seq);
-                            toAdd = false;
-                            break;
-                        }
-                    }
-                }
-
-                if (toAdd)
-                {
-                    result.Add(seq);
                 }
             }
 
             if (withDupColumns.Any())
             {
+                result = result.Except(withDupColumns).ToList();
                 errors.Add(new CogniteError<SequenceCreate>
                 {
                     Status = 409,
@@ -307,29 +264,14 @@ namespace Cognite.Extensions
                 });
             }
 
-            if (duplicated.Any())
-            {
-                errors.Add(new CogniteError<SequenceCreate>
-                {
-                    Status = 409,
-                    Message = "Duplicate external ids",
-                    Resource = ResourceType.ExternalId,
-                    Type = ErrorType.ItemDuplicated,
-                    Values = duplicated.Select(item => Identity.Create(item)).ToArray()
-                });
-            }
-            if (bad.Any())
-            {
-                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError<SequenceCreate>
-                {
-                    Skipped = group.Select(pair => pair.Item2).ToList(),
-                    Resource = group.Key,
-                    Type = ErrorType.SanitationFailed,
-                    Status = 400
-                }));
-            }
             return (result, errors);
         }
+
+        private static readonly DistinctResource<SequenceDataCreate>[] sequenceDataDistinct = new[]
+        {
+            new DistinctResource<SequenceDataCreate>("Duplicate internal or external ids",
+                ResourceType.Id, s => s.Id.HasValue ? Identity.Create(s.Id.Value) : Identity.Create(s.ExternalId))
+        };
 
         /// <summary>
         /// Clean list of SequenceDataCreate objects, sanitizing each and removing any duplicates.
@@ -344,50 +286,35 @@ namespace Cognite.Extensions
             IEnumerable<SequenceDataCreate> sequences,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (sequences, Enumerable.Empty<CogniteError<SequenceRowError>>());
-            if (sequences == null) throw new ArgumentNullException(nameof(sequences));
+            var (result, errors) = CleanRequest(sequenceDataDistinct, sequences, Verify, Sanitize, mode);
 
-            var result = new List<SequenceDataCreate>();
-            var errors = new List<CogniteError<SequenceRowError>>();
+            var convErrors = errors
+                .Select(e => e.ReplaceSkipped(s =>
+                    new SequenceRowError(s.Rows, s.Id.HasValue ? Identity.Create(s.Id.Value) : Identity.Create(s.ExternalId))))
+                .ToList();
 
-            var ids = new HashSet<Identity>();
-            var duplicated = new HashSet<Identity>();
+            if (mode == SanitationMode.None) return (result, convErrors);
+
             var bad = new List<(ResourceType Type, SequenceDataCreate Seq)>();
 
             var badRowSequences = new List<(ResourceType, SequenceRowError)>();
             var dupRowErrors = new List<SequenceRowError>();
             var dupColumnErrors = new List<SequenceRowError>();
 
+            var nextResult = new List<SequenceDataCreate>();
 
-            foreach (var seq in sequences)
+            foreach (var seq in result)
             {
                 var columns = new HashSet<string>();
                 var duplicatedColumns = new HashSet<string>();
                 bool toAdd = true;
 
-                if (mode == SanitationMode.Clean)
-                {
-                    seq.Sanitize();
-                }
-                var failedField = seq.Verify();
-                if (failedField.HasValue)
-                {
-                    bad.Add((failedField.Value, seq));
-                    toAdd = false;
-                }
-
-                var idt = seq.Id.HasValue ? Identity.Create(seq.Id.Value) : Identity.Create(seq.ExternalId);
-
-                if (!ids.Add(idt))
-                {
-                    duplicated.Add(idt);
-                    toAdd = false;
-                }
-
                 var badRows = new List<(ResourceType Type, SequenceRow Row)>();
 
                 var rowNums = new HashSet<long>();
                 var duplicateRows = new List<SequenceRow>();
+
+                var idt = seq.Id.HasValue ? Identity.Create(seq.Id.Value) : Identity.Create(seq.ExternalId);
 
                 if (seq.Columns != null && seq.Rows != null)
                 {
@@ -395,7 +322,7 @@ namespace Cognite.Extensions
                     foreach (var row in seq.Rows)
                     {
                         bool addRow = true;
-                        failedField = row.Verify(seq);
+                        var failedField = row.Verify(seq);
                         if (failedField.HasValue)
                         {
                             badRows.Add((failedField.Value, row));
@@ -462,14 +389,13 @@ namespace Cognite.Extensions
 
                 if (toAdd)
                 {
-                    result.Add(seq);
+                    nextResult.Add(seq);
                 }
-
             }
 
             if (dupColumnErrors.Any())
             {
-                errors.Add(new CogniteError<SequenceRowError>
+                convErrors.Add(new CogniteError<SequenceRowError>
                 {
                     Status = 409,
                     Message = "Duplicate columns in request",
@@ -481,7 +407,7 @@ namespace Cognite.Extensions
 
             if (dupRowErrors.Any())
             {
-                errors.Add(new CogniteError<SequenceRowError>
+                convErrors.Add(new CogniteError<SequenceRowError>
                 {
                     Status = 409,
                     Message = "Duplicate row numbers",
@@ -491,20 +417,9 @@ namespace Cognite.Extensions
                 });
             }
 
-            if (duplicated.Any())
-            {
-                errors.Add(new CogniteError<SequenceRowError>
-                {
-                    Status = 409,
-                    Message = "Duplicate internal or external ids",
-                    Resource = ResourceType.Id,
-                    Type = ErrorType.ItemDuplicated,
-                    Values = duplicated.ToArray()
-                });
-            }
             if (bad.Any())
             {
-                errors.AddRange(bad.GroupBy(pair => pair.Type).Select(group => new CogniteError<SequenceRowError>
+                convErrors.AddRange(bad.GroupBy(pair => pair.Type).Select(group => new CogniteError<SequenceRowError>
                 {
                     Skipped = group.Select(pair => new SequenceRowError(
                         pair.Seq.Rows,
@@ -517,7 +432,7 @@ namespace Cognite.Extensions
             }
             if (badRowSequences.Any())
             {
-                errors.AddRange(badRowSequences.GroupBy(pair => pair.Item1).Select(group => new CogniteError<SequenceRowError>
+                convErrors.AddRange(badRowSequences.GroupBy(pair => pair.Item1).Select(group => new CogniteError<SequenceRowError>
                 {
                     Skipped = group.Select(pair => pair.Item2),
                     Resource = group.Key,
@@ -525,7 +440,7 @@ namespace Cognite.Extensions
                     Status = 400,
                 }));
             }
-            return (result, errors);
+            return (nextResult, convErrors);
         }
     }
 }

--- a/Cognite.Extensions/TimeSeries/TimeSeriesResultHandlers.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesResultHandlers.cs
@@ -60,10 +60,10 @@ namespace Cognite.Extensions
         {
             return error.Resource switch
             {
-                ResourceType.DataSetId => ts.DataSetId.HasValue && badValues.Contains(Identity.Create(ts.DataSetId.Value)),
-                ResourceType.ExternalId => ts.ExternalId != null && badValues.Contains(Identity.Create(ts.ExternalId)),
-                ResourceType.AssetId => ts.AssetId.HasValue && badValues.Contains(Identity.Create(ts.AssetId.Value)),
-                ResourceType.LegacyName => ts.LegacyName != null && badValues.Contains(Identity.Create(ts.LegacyName)),
+                ResourceType.DataSetId => badValues.ContainsIdentity(ts.DataSetId),
+                ResourceType.ExternalId => badValues.ContainsIdentity(ts.ExternalId),
+                ResourceType.AssetId => badValues.ContainsIdentity(ts.AssetId),
+                ResourceType.LegacyName => badValues.ContainsIdentity(ts.LegacyName),
                 _ => false,
             };
         }

--- a/Cognite.Extensions/TimeSeries/TimeSeriesResultHandlers.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesResultHandlers.cs
@@ -55,6 +55,19 @@ namespace Cognite.Extensions
                 }
             }
         }
+
+        private static bool IsAffected(TimeSeriesCreate ts, HashSet<Identity> badValues, CogniteError<TimeSeriesCreate> error)
+        {
+            return error.Resource switch
+            {
+                ResourceType.DataSetId => ts.DataSetId.HasValue && badValues.Contains(Identity.Create(ts.DataSetId.Value)),
+                ResourceType.ExternalId => ts.ExternalId != null && badValues.Contains(Identity.Create(ts.ExternalId)),
+                ResourceType.AssetId => ts.AssetId.HasValue && badValues.Contains(Identity.Create(ts.AssetId.Value)),
+                ResourceType.LegacyName => ts.LegacyName != null && badValues.Contains(Identity.Create(ts.LegacyName)),
+                _ => false,
+            };
+        }
+
         /// <summary>
         /// Clean list of TimeSeriesCreate objects based on CogniteError
         /// </summary>
@@ -65,60 +78,9 @@ namespace Cognite.Extensions
             CogniteError<TimeSeriesCreate> error,
             IEnumerable<TimeSeriesCreate> timeseries)
         {
-            if (timeseries == null)
-            {
-                throw new ArgumentNullException(nameof(timeseries));
-            }
-            if (error == null) return timeseries;
-            if (!error.Values?.Any() ?? true)
-            {
-                error.Values = timeseries.Where(ts => ts.ExternalId != null).Select(ts => Identity.Create(ts.ExternalId));
-                return Array.Empty<TimeSeriesCreate>();
-            }
-
-            var items = new HashSet<Identity>(error.Values);
-
-            var ret = new List<TimeSeriesCreate>();
-            var skipped = new List<TimeSeriesCreate>();
-
-            foreach (var ts in timeseries)
-            {
-                bool added = false;
-                switch (error.Resource)
-                {
-                    case ResourceType.DataSetId:
-                        if (!ts.DataSetId.HasValue || !items.Contains(Identity.Create(ts.DataSetId.Value))) added = true;
-                        break;
-                    case ResourceType.ExternalId:
-                        if (ts.ExternalId == null || !items.Contains(Identity.Create(ts.ExternalId))) added = true;
-                        break;
-                    case ResourceType.AssetId:
-                        if (!ts.AssetId.HasValue || !items.Contains(Identity.Create(ts.AssetId.Value))) added = true;
-                        break;
-                    case ResourceType.LegacyName:
-                        if (ts.LegacyName == null || !items.Contains(Identity.Create(ts.LegacyName))) added = true;
-                        break;
-                }
-                if (added)
-                {
-                    ret.Add(ts);
-                }
-                else
-                {
-                    CdfMetrics.TimeSeriesSkipped.Inc();
-                    skipped.Add(ts);
-                }
-            }
-            if (skipped.Any())
-            {
-                error.Skipped = skipped;
-            }
-            else
-            {
-                error.Skipped = timeseries;
-                return Array.Empty<TimeSeriesCreate>();
-            }
-            return ret;
+            return CleanFromErrorCommon(error, timeseries, IsAffected,
+                ts => ts.ExternalId == null ? null : Identity.Create(ts.ExternalId),
+                CdfMetrics.TimeSeriesSkipped);
         }
     }
 }

--- a/Cognite.Extensions/TimeSeries/TimeSeriesSanitation.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesSanitation.cs
@@ -84,9 +84,9 @@ namespace Cognite.Extensions
         private static readonly DistinctResource<TimeSeriesCreate>[] timeSeriesDistinct = new[]
         {
             new DistinctResource<TimeSeriesCreate>("Duplicated externalIds", ResourceType.ExternalId,
-                ts => Identity.Create(ts.ExternalId)),
+                ts => ts.ExternalId != null ? Identity.Create(ts.ExternalId) : null),
             new DistinctResource<TimeSeriesCreate>("Duplicated metric names in request", ResourceType.LegacyName,
-                ts => Identity.Create(ts.LegacyName))
+                ts => ts.LegacyName != null ? Identity.Create(ts.LegacyName) : null)
         };
 
         /// <summary>

--- a/Cognite.Extensions/TimeSeries/TimeSeriesSanitation.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesSanitation.cs
@@ -81,6 +81,14 @@ namespace Cognite.Extensions
             return null;
         }
 
+        private static readonly DistinctResource<TimeSeriesCreate>[] timeSeriesDistinct = new[]
+        {
+            new DistinctResource<TimeSeriesCreate>("Duplicated externalIds", ResourceType.ExternalId,
+                ts => Identity.Create(ts.ExternalId)),
+            new DistinctResource<TimeSeriesCreate>("Duplicated metric names in request", ResourceType.LegacyName,
+                ts => Identity.Create(ts.LegacyName))
+        };
+
         /// <summary>
         /// Clean list of TimeSeriesCreate objects, sanitizing each and removing any duplicates.
         /// The first encountered duplicate is kept.
@@ -92,93 +100,7 @@ namespace Cognite.Extensions
             IEnumerable<TimeSeriesCreate> timeseries,
             SanitationMode mode)
         {
-            if (mode == SanitationMode.None) return (timeseries, Enumerable.Empty<CogniteError<TimeSeriesCreate>>());
-            if (timeseries == null)
-            {
-                throw new ArgumentNullException(nameof(timeseries));
-            }
-            var result = new List<TimeSeriesCreate>();
-            var errors = new List<CogniteError<TimeSeriesCreate>>();
-
-            var ids = new HashSet<string>();
-            var duplicatedIds = new HashSet<string>();
-
-            var names = new HashSet<string>();
-            var duplicatedNames = new HashSet<string>();
-
-            var bad = new List<(ResourceType, TimeSeriesCreate)>();
-
-
-            foreach (var ts in timeseries)
-            {
-                bool toAdd = true;
-                if (mode == SanitationMode.Remove)
-                {
-                    var failedField = ts.Verify();
-                    if (failedField.HasValue)
-                    {
-                        bad.Add((failedField.Value, ts));
-                        toAdd = false;
-                    }
-                }
-                else if (mode == SanitationMode.Clean)
-                {
-                    ts.Sanitize();
-                }
-                if (ts.ExternalId != null)
-                {
-                    if (!ids.Add(ts.ExternalId))
-                    {
-                        duplicatedIds.Add(ts.ExternalId);
-                        toAdd = false;
-                    }
-                }
-                if (ts.LegacyName != null)
-                {
-                    if (!names.Add(ts.LegacyName))
-                    {
-                        duplicatedNames.Add(ts.LegacyName);
-                        toAdd = false;
-                    }
-                }
-                if (toAdd)
-                {
-                    result.Add(ts);
-                }
-            }
-            if (duplicatedIds.Any())
-            {
-                errors.Add(new CogniteError<TimeSeriesCreate>
-                {
-                    Status = 409,
-                    Message = "Conflicting identifiers",
-                    Resource = ResourceType.ExternalId,
-                    Type = ErrorType.ItemDuplicated,
-                    Values = duplicatedIds.Select(Identity.Create).ToArray()
-                });
-            }
-            if (duplicatedNames.Any())
-            {
-                errors.Add(new CogniteError<TimeSeriesCreate>
-                {
-                    Status = 409,
-                    Message = "Duplicated metric names in request",
-                    Resource = ResourceType.LegacyName,
-                    Type = ErrorType.ItemDuplicated,
-                    Values = duplicatedNames.Select(Identity.Create).ToArray()
-                });
-            }
-            if (bad.Any())
-            {
-                errors.AddRange(bad.GroupBy(pair => pair.Item1).Select(group => new CogniteError<TimeSeriesCreate>
-                {
-                    Skipped = group.Select(pair => pair.Item2).ToList(),
-                    Resource = group.Key,
-                    Type = ErrorType.SanitationFailed,
-                    Status = 400
-                }));
-            }
-            return (result, errors);
+            return CleanRequest(timeSeriesDistinct, timeseries, Verify, Sanitize, mode);
         }
     }
 }

--- a/Cognite.Extensions/TimeSeries/TimeSeriesUpdateResultHandlers.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesUpdateResultHandlers.cs
@@ -70,9 +70,9 @@ namespace Cognite.Extensions
             var update = item.Update;
             return error.Resource switch
             {
-                ResourceType.DataSetId => update.DataSetId?.Set != null && badValues.Contains(Identity.Create(update.DataSetId.Set.Value)),
-                ResourceType.ExternalId => update.ExternalId?.Set != null && badValues.Contains(Identity.Create(update.ExternalId.Set)),
-                ResourceType.AssetId => update.AssetId?.Set != null && badValues.Contains(Identity.Create(update.AssetId.Set.Value)),
+                ResourceType.DataSetId => badValues.ContainsIdentity(update.DataSetId?.Set),
+                ResourceType.ExternalId => badValues.ContainsIdentity(update.ExternalId?.Set),
+                ResourceType.AssetId => badValues.ContainsIdentity(update.AssetId?.Set),
                 ResourceType.Id => badValues.Contains(item),
                 _ => false
             };

--- a/Cognite.Extensions/TimeSeries/TimeSeriesUpdateResultHandlers.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesUpdateResultHandlers.cs
@@ -62,6 +62,22 @@ namespace Cognite.Extensions
             }
         }
 
+        private static bool IsAffected(
+            TimeSeriesUpdateItem item,
+            HashSet<Identity> badValues,
+            CogniteError<TimeSeriesUpdateItem> error)
+        {
+            var update = item.Update;
+            return error.Resource switch
+            {
+                ResourceType.DataSetId => update.DataSetId?.Set != null && badValues.Contains(Identity.Create(update.DataSetId.Set.Value)),
+                ResourceType.ExternalId => update.ExternalId?.Set != null && badValues.Contains(Identity.Create(update.ExternalId.Set)),
+                ResourceType.AssetId => update.AssetId?.Set != null && badValues.Contains(Identity.Create(update.AssetId.Set.Value)),
+                ResourceType.Id => badValues.Contains(item),
+                _ => false
+            };
+        }
+
         /// <summary>
         /// Clean list of TimeSeriesUpdateItem objects based on CogniteError
         /// </summary>
@@ -72,67 +88,7 @@ namespace Cognite.Extensions
             CogniteError<TimeSeriesUpdateItem> error,
             IEnumerable<TimeSeriesUpdateItem> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
-            if (error == null) return items;
-            if (!error.Values?.Any() ?? true)
-            {
-                error.Values = items.Where(ts => ts.ExternalId != null).Select(ts => Identity.Create(ts.ExternalId));
-                return Array.Empty<TimeSeriesUpdateItem>();
-            }
-
-            var badValues = new HashSet<Identity>(error.Values);
-
-            var ret = new List<TimeSeriesUpdateItem>();
-            var skipped = new List<TimeSeriesUpdateItem>();
-
-            foreach (var item in items)
-            {
-                bool added = false;
-                var update = item.Update;
-
-                switch (error.Resource)
-                {
-                    case ResourceType.DataSetId:
-                        if (update.DataSetId?.Set == null
-                            || !badValues.Contains(Identity.Create(update.DataSetId.Set.Value))) added = true;
-                        break;
-                    case ResourceType.ExternalId:
-                        if (update.ExternalId?.Set == null
-                            || !badValues.Contains(Identity.Create(update.ExternalId.Set))) added = true;
-                        break;
-                    case ResourceType.AssetId:
-                        if (update.AssetId?.Set == null
-                            || !badValues.Contains(Identity.Create(update.AssetId.Set.Value))) added = true;
-                        break;
-                    case ResourceType.Id:
-                        var idt = item.Id.HasValue ? Identity.Create(item.Id.Value) : Identity.Create(item.ExternalId);
-
-                        if (!badValues.Contains(idt)) added = true;
-                        break;
-                }
-                if (added)
-                {
-                    ret.Add(item);
-                }
-                else
-                {
-                    CdfMetrics.TimeSeriesSkipped.Inc();
-                    skipped.Add(item);
-                }
-            }
-            if (skipped.Any())
-            {
-                error.Skipped = skipped;
-            }
-            else
-            {
-                error.Skipped = items;
-                return Enumerable.Empty<TimeSeriesUpdateItem>();
-            }
-            return ret;
+            return CleanFromErrorCommon(error, items, IsAffected, item => item, CdfMetrics.TimeSeriesUpdatesSkipped);
         }
     }
 }

--- a/Cognite.Extensions/TypeExtensions.cs
+++ b/Cognite.Extensions/TypeExtensions.cs
@@ -161,7 +161,6 @@ namespace Cognite.Extensions
 
             return new TimeSeriesUpdateItem(old.Id) { Update = upd };
         }
-
     }
 
     /// <summary>

--- a/ExtractorUtils.Test/unit/CogniteResultTests.cs
+++ b/ExtractorUtils.Test/unit/CogniteResultTests.cs
@@ -48,7 +48,7 @@ namespace ExtractorUtils.Test.Unit
         }
 
         [Fact]
-        public async Task CleanAssetRequest()
+        public void CleanAssetRequest()
         {
             var assets = new[]
             {
@@ -108,8 +108,7 @@ namespace ExtractorUtils.Test.Unit
             {
                 var error = ResultHandlers.ParseException<AssetCreate>(exceptions[i], RequestType.CreateAssets);
                 logger.LogCogniteError(error, RequestType.CreateAssets, false, LogLevel.Debug, LogLevel.Warning);
-                assets = (await ResultHandlers.CleanFromError(null, error, assets, 1000, 1, CancellationToken.None))
-                    .ToArray();
+                assets = ResultHandlers.CleanFromError(error, assets).ToArray();
                 Assert.Equal(9 - i * 2 - 2, assets.Count());
                 errors.Add(error);
             }

--- a/ExtractorUtils.Test/unit/SanitationTest.cs
+++ b/ExtractorUtils.Test/unit/SanitationTest.cs
@@ -820,17 +820,18 @@ namespace ExtractorUtils.Test.Unit
             var errs = errors.ToList();
             Assert.Equal(4, result.Count());
             Assert.Equal(3, errors.Count());
-            var err = errs[1];
+
+            var err = errs[0];
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(ResourceType.ExternalId, err.Resource);
             Assert.Equal(2, err.Values.Count());
 
-            err = errs[2];
+            err = errs[1];
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Equal(ResourceType.SequenceColumns, err.Resource);
             Assert.Equal(2, err.Skipped.Count());
 
-            err = errs[0];
+            err = errs[2];
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(ResourceType.ColumnExternalId, err.Resource);
             Assert.Equal(2, err.Skipped.Count());
@@ -887,44 +888,49 @@ namespace ExtractorUtils.Test.Unit
 
             var (result, errors) = Sanitation.CleanSequenceDataRequest(sequences, SanitationMode.Remove);
             Assert.Equal(6, result.Count());
-            Assert.Equal(7, errors.Count());
+            Assert.Equal(8, errors.Count());
 
             var errs = errors.ToList();
             
-            var err = errs[1];
+            var err = errs[4];
             Assert.Equal(ResourceType.SequenceRowNumber, err.Resource);
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(409, err.Status);
             Assert.Single(err.Skipped);
 
-            err = errs[0];
+            err = errs[3];
             Assert.Equal(ResourceType.ColumnExternalId, err.Resource);
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(409, err.Status);
             Assert.Single(err.Skipped);
 
-            err = errs[2];
+            err = errs[0];
             Assert.Equal(ResourceType.Id, err.Resource);
             Assert.Equal(ErrorType.ItemDuplicated, err.Type);
             Assert.Equal(409, err.Status);
             Assert.Equal(2, err.Values.Count());
 
-            err = errs[3];
+            err = errs[1];
             Assert.Equal(ResourceType.SequenceColumns, err.Resource);
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Single(err.Skipped);
 
-            err = errs[4];
+            err = errs[2];
             Assert.Equal(ResourceType.SequenceRows, err.Resource);
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
-            Assert.Equal(2, err.Skipped.Count());
+            Assert.Single(err.Skipped);
 
             err = errs[5];
+            Assert.Equal(ResourceType.SequenceRows, err.Resource);
+            Assert.Equal(ErrorType.SanitationFailed, err.Type);
+            Assert.Single(err.Skipped);
+
+            err = errs[6];
             Assert.Equal(ResourceType.SequenceRowValues, err.Resource);
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Equal(3, err.Skipped.Count());
 
-            err = errs[6];
+            err = errs[7];
             Assert.Equal(ResourceType.SequenceRowNumber, err.Resource);
             Assert.Equal(ErrorType.SanitationFailed, err.Type);
             Assert.Single(err.Skipped);


### PR DESCRIPTION
Code to generalize the CleanFromError and CleanRequest methods. These contain a lot of common logic in most cases, so we can create a common base method and call that, reducing complexity and code duplication.

This could be made easier with native SDK methods for getting Identity from the DTOs.