### PR TITLE
Fix unpleasant deadlock in ExtractorRunner

### DIFF
--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -369,7 +369,7 @@ namespace Cognite.Extractor.Utils
 
 
             }
-            Console.CancelKeyPress -= CancelKeyPressHandler;
+            _ = Task.Run(() => Console.CancelKeyPress -= CancelKeyPressHandler, CancellationToken.None).ConfigureAwait(false);
         }
 
 


### PR DESCRIPTION
This one is really ugly. It is compiler dependent, and probably _optimization level dependent_ Essentially what happens is that the compiler can decide to inline the continuation after calling `CancellationTokenSource.Cancel()`. so calling "remove" on the event handler happens inside the event handler itself, and deadlocks. Running it in a separate task should fix the problem, but this one is really unpleasant.