### PR TITLE
Fix race condition in TaskThrottler

### DIFF
--- a/Cognite.Common/TaskThrottler.cs
+++ b/Cognite.Common/TaskThrottler.cs
@@ -319,8 +319,6 @@ namespace Cognite.Extractor.Common
                         catch (TaskCanceledException)
                         {
                         }
-                        
-
                     }
                     else
                     {
@@ -338,15 +336,9 @@ namespace Cognite.Extractor.Common
                     _taskCompletionEvent.Reset();
                 }
 
-
                 lock (_lock)
                 {
                     if (_quitOnFailure && _runningTasks.Any(result => result.Task != null && result.Task.IsFaulted)) break;
-                }
-
-                if (_source.IsCancellationRequested || _generators.IsCompleted)
-                {
-                    await Task.WhenAll(_runningTasks.Select(result => result.Task)).ConfigureAwait(false);
                 }
 
                 lock (_lock)
@@ -367,6 +359,10 @@ namespace Cognite.Extractor.Common
                         || result.Task.IsFaulted);
                 }
             }
+
+            await Task.WhenAll(
+                _runningTasks.Select(result => result.Task)
+                .Where(task => task != null && !task.IsCompleted)).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
We waited for tasks to complete inside the loop, which meant that if cancelation of the loop was requested while it was in the part of the code _after_ that (for example waiting on the mutex), they would never be awaited.

There is no real reason to wait inside the loop, we can just wait outside it, it is effectively the same.