### PR TITLE
Separate logic for restarting on config and on error

### DIFF
--- a/ExtractorUtils/ExtractionRun.cs
+++ b/ExtractorUtils/ExtractionRun.cs
@@ -86,7 +86,6 @@ namespace Cognite.Extractor.Utils
             {
                 _log.LogWarning("Failed to fetch extraction pipeline with ExternalId: {id}, reporting status may fail, if it does not exist: {msg}",
                     _config.PipelineId, ex.Message);
-                return;
             }
 
             _log.LogInformation("Begin reporting extraction runs to pipeline with id {id}. Continuous: {cont}", _config.PipelineId, Continuous);

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -90,6 +90,10 @@ namespace Cognite.Extractor.Utils
         /// Method to build logger from config. Defaults to <see cref="LoggingUtils.GetConfiguredLogger(LoggerConfig)"/>
         /// </summary>
         public Func<LoggerConfig, Serilog.ILogger>? BuildLogger { get; set; }
+        /// <summary>
+        /// Wait for config to be loaded, even if Restart is set to false.
+        /// </summary>
+        public bool WaitForConfig { get; set; } = true;
     }
 
 
@@ -261,15 +265,15 @@ namespace Cognite.Extractor.Utils
                     if (options.StartupLogger != null)
                     {
                         options.StartupLogger.LogError("Invalid configuration file: {msg}", exception.Message);
-                        if (!options.Restart) options.StartupLogger.LogInformation("Sleeping for 30 seconds");
+                        if (options.WaitForConfig || options.Restart) options.StartupLogger.LogInformation("Sleeping for 30 seconds");
                     }
                     else
                     {
                         Serilog.Log.Logger = LoggingUtils.GetSerilogDefault();
                         Serilog.Log.Error("Invalid configuration file: " + exception.Message);
-                        if (!options.Restart) Serilog.Log.Information("Sleeping for 30 seconds");
+                        if (options.WaitForConfig || options.Restart) Serilog.Log.Information("Sleeping for 30 seconds");
                     }
-                    if (!options.Restart) break;
+                    if (!options.WaitForConfig && !options.Restart) break;
                     try
                     {
                         await Task.Delay(30_000, source.Token).ConfigureAwait(false);


### PR DESCRIPTION
This helps for extractors that are not continuous. We may want these to restart on missing config, but not otherwise.