### PR TITLE
Suppress object disposed errors on extractor close

### DIFF
--- a/Cognite.Metrics/MetricsService.cs
+++ b/Cognite.Metrics/MetricsService.cs
@@ -114,7 +114,7 @@ namespace Cognite.Extractor.Metrics
                     {
                         _logger.LogError("Metrics push attempt timed out after retrying");
                     }
-                    else
+                    else if (!(e is ObjectDisposedException))
                     {
                         _logger.LogError("Metrics push error: " + e.Message);
                     }

--- a/ExampleExtractor/ExampleExtractor.csproj
+++ b/ExampleExtractor/ExampleExtractor.csproj
@@ -10,4 +10,10 @@
     <ProjectReference Include="..\ExtractorUtils\ExtractorUtils.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="config.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -24,7 +24,7 @@ class MyExtractor : BaseExtractor<BaseConfig>
                 Name = "Sine Wave"
             }
         }, RetryMode.OnError, SanitationMode.Clean, Source.Token).ConfigureAwait(false);
-        result.Throw();
+        result.ThrowOnFatal();
         CreateTimeseriesQueue(1000, TimeSpan.FromSeconds(1), null);
         ScheduleDatapointsRun("datapoints", TimeSpan.FromMilliseconds(100), token =>
         {


### PR DESCRIPTION
This is caused by polly retries triggering during dispose, which apparently can cause issues. There might be some underlying issue, but I couldn't figure it out.