### PR TITLE
Command line utility

### DIFF
--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.41.0" />
-    <PackageReference Include="CogniteSdk" Version="2.2.0-beta-003" />
+    <PackageReference Include="CogniteSdk" Version="3.0.0" />
     <PackageReference Include="prometheus-net" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -62,14 +62,14 @@ class Program
         {
             // This can also be invoked directly in main, to not have a CLI.
             await ExtractorRunner.Run<BaseConfig, MyExtractor>(
-                opt.ConfigPath ?? "config.yml",
-                new[] { 1 },
-                "my-extractor",
-                "myextractor/1.0.0",
-                false,
-                true,
-                true,
-                true,
+                configPath: opt.ConfigPath ?? "config.yml",
+                acceptedConfigVersions: new[] { 1 },
+                appId: "my-extractor",
+                userAgent: "myextractor/1.0.0",
+                addStateStore: false,
+                addLogger: true,
+                addMetrics: true,
+                restart: true,
                 CancellationToken.None).ConfigureAwait(false);
         }, binder);
 

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -7,6 +7,8 @@ using Cognite.Extensions;
 using System;
 using System.Collections.Generic;
 using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils.CommandLine;
+using System.CommandLine;
 
 class MyExtractor : BaseExtractor<BaseConfig>
 {
@@ -37,20 +39,40 @@ class MyExtractor : BaseExtractor<BaseConfig>
     }
 }
 
+// Class for flat command line arguments
+class Options
+{
+    [CommandLineOption("Specify command line argument", true, "-c")]
+    public string ConfigPath { get; set; }
+}
+
 // Then, in the Main() method:
 class Program
 {
-    static async Task Main()
+    static async Task Main(string[] args)
     {
-        await ExtractorRunner.Run<BaseConfig, MyExtractor>(
-            "config.yml",
-            new[] { 1 },
-            "my-extractor",
-            "myextractor/1.0.0",
-            false,
-            true,
-            true,
-            true,
-            CancellationToken.None).ConfigureAwait(true);
+        var command = new RootCommand
+        {
+            Description = "Simple example extractor"
+        };
+        var binder = new AttributeBinder<Options>();
+        binder.AddOptionsToCommand(command);
+
+        command.SetHandler<Options>(async opt =>
+        {
+            // This can also be invoked directly in main, to not have a CLI.
+            await ExtractorRunner.Run<BaseConfig, MyExtractor>(
+                opt.ConfigPath ?? "config.yml",
+                new[] { 1 },
+                "my-extractor",
+                "myextractor/1.0.0",
+                false,
+                true,
+                true,
+                true,
+                CancellationToken.None).ConfigureAwait(false);
+        }, binder);
+
+        await command.InvokeAsync(args).ConfigureAwait(false);
     }
 }

--- a/ExtractorUtils.Test/ExtractorUtils.Test.csproj
+++ b/ExtractorUtils.Test/ExtractorUtils.Test.csproj
@@ -5,7 +5,7 @@
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/ExtractorUtils.Test/unit/CommandLineTest.cs
+++ b/ExtractorUtils.Test/unit/CommandLineTest.cs
@@ -1,0 +1,65 @@
+﻿using Cognite.Extractor.Testing;
+using Cognite.Extractor.Utils.CommandLine;
+using System.CommandLine;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ExtractorUtils.Test.Unit
+{
+    internal class CliType
+    {
+        [CommandLineOption("Some string type", true, "-s", "-t")]
+        public string StringType { get; set; }
+        [CommandLineOption("Some int type", false, "-i")]
+        public int IntType { get; set; }
+        [CommandLineOption("Some flag type", false, "-b")]
+        public bool Flag { get; set; }
+        public bool IgnoredOption { get; set; }
+    }
+
+
+    public class CommandLineTest : ConsoleWrapper
+    {
+        public CommandLineTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void TestSimpleCliType()
+        {
+            var binder = new AttributeBinder<CliType>();
+            var command = new RootCommand()
+            {
+                Description = "My description"
+            };
+            binder.AddOptionsToCommand(command);
+
+            command.SetHandler<CliType>(result =>
+            {
+                Assert.Equal("stringvalue", result.StringType);
+                Assert.Equal(123, result.IntType);
+                Assert.True(result.Flag);
+                Assert.False(result.IgnoredOption);
+            }, binder);
+
+            Assert.Equal(0, command.Invoke("--string-type stringvalue -b -i 123"));
+        }
+
+        [Fact]
+        public void LibBugTest()
+        {
+            // This shows a bug in System.CommandLine, once this fails we can remove the workaround from AttributeBinder
+
+            var arg = new Option<bool>(new[] { "-b" }, "Some description");
+
+            var cmd = new RootCommand
+            {
+                arg
+            };
+
+            var res = cmd.Parse("-b");
+
+            Assert.False((bool)res.GetValueForOption((Option)arg));
+        }
+    }
+}

--- a/ExtractorUtils/CommandLine/AttributeBinder.cs
+++ b/ExtractorUtils/CommandLine/AttributeBinder.cs
@@ -1,0 +1,107 @@
+﻿using Cognite.Extractor.StateStorage;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Binding;
+using System.Linq;
+
+namespace Cognite.Extractor.Utils.CommandLine
+{
+    /// <summary>
+    /// Binder class for objects built with CommandLineOptionAttribute.
+    /// </summary>
+    /// <typeparam name="T">Type to create. Must have a parameterless constructor.</typeparam>
+    public class AttributeBinder<T> : BinderBase<T>
+    {
+        /// <summary>
+        /// Built options, options here can be modified.
+        /// They are organized by property name.
+        /// You can also manually add options to the binder here, if you need custom logic.
+        /// </summary>
+        public Dictionary<string, Option> Options { get; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public AttributeBinder()
+        {
+            Options = new Dictionary<string, Option>();
+            BuildCommandOptions();
+        }
+
+        /// <summary>
+        /// Add build attributes to the given command, so that this binder can be used with it.
+        /// </summary>
+        /// <param name="command">Command to add to</param>
+        public void AddOptionsToCommand(Command command)
+        {
+            if (command == null) throw new ArgumentNullException(nameof(Command));
+
+            foreach (var kvp in Options)
+            {
+                command.AddOption(kvp.Value);
+            }
+        }
+
+        private void BuildCommandOptions()
+        {
+            var type = typeof(T);
+
+            var props = type.GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+            
+            foreach (var prop in props)
+            {
+                if (!(prop.GetCustomAttributes(typeof(CommandLineOptionAttribute), true).FirstOrDefault() is CommandLineOptionAttribute attr)) continue;
+
+                var aliases = new List<string>();
+                if (attr.IncludePropertyName)
+                {
+                    aliases.Add($"--{prop.Name.ToSnakeCase()}");
+                }
+                if (attr.Aliases != null)
+                {
+                    aliases.AddRange(attr.Aliases);
+                }
+                Option option;
+                var optType = typeof(Option<>).MakeGenericType(prop.PropertyType);
+                option = (Option)Activator.CreateInstance(optType, aliases.ToArray(), attr.Description);
+
+                Options[prop.Name] = option;
+            }
+        }
+
+        /// <summary>
+        /// Create an instance of <typeparamref name="T"/>, and bind to it using options constructed from
+        /// CommandLineOptionAttributes.
+        /// </summary>
+        /// <param name="bindingContext">Context</param>
+        /// <returns>An instance of <typeparamref name="T"/> with fields filled from command line.</returns>
+        protected override T GetBoundValue(BindingContext bindingContext)
+        {
+            if (bindingContext == null) throw new ArgumentNullException(nameof(bindingContext));
+
+            var type = typeof(T);
+            var result = Activator.CreateInstance(type);
+            var props = type.GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+
+            foreach (var prop in props)
+            {
+                if (!prop.CanWrite) continue;
+                if (!Options.TryGetValue(prop.Name, out var option)) continue;
+
+                if (option.GetType() == typeof(Option<>).MakeGenericType(typeof(bool)))
+                {
+                    prop.SetValue(result, bindingContext.ParseResult.GetValueForOption((Option<bool>)option));
+                }
+                else
+                {
+                    var res = bindingContext.ParseResult.GetValueForOption(option);
+                    prop.SetValue(result, res);
+                }
+                
+            }
+
+            return (T)result;
+        }
+    }
+}

--- a/ExtractorUtils/CommandLine/CommandLineOptionAttribute.cs
+++ b/ExtractorUtils/CommandLine/CommandLineOptionAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+
+namespace Cognite.Extractor.Utils.CommandLine
+{
+    /// <summary>
+    /// Utility attribute for building flat command line interfaces using System.CommandLine
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class CommandLineOptionAttribute : Attribute
+    {
+        /// <summary>
+        /// List of aliases.
+        /// </summary>
+        public IEnumerable<string> Aliases { get; }
+        /// <summary>
+        /// Description of command.
+        /// </summary>
+        public string Description { get; }
+        /// <summary>
+        /// True to include the name of the property itself as an alias, converted to snake-case.
+        /// </summary>
+        public bool IncludePropertyName { get; }
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="description">Description of command.</param>
+        /// <param name="includePropertyName">True to include the name of the property itself as an alias, converted to snake-case.
+        /// </param>
+        /// <param name="aliases">List of aliases.</param>
+        public CommandLineOptionAttribute(
+            string description = "",
+            bool includePropertyName = true,
+           params string[] aliases)
+        {
+            Description = description;
+            Aliases = aliases;
+            IncludePropertyName = includePropertyName;
+        }
+    }
+}

--- a/ExtractorUtils/ExtractorUtils.csproj
+++ b/ExtractorUtils/ExtractorUtils.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cognite.Config\Cognite.Configuration.csproj" />


### PR DESCRIPTION
We've made command line interfaces like this for several extractors. The System.CommandLine library broke the old way of doing it, and it was also quite verbose. This adds a simple attribute-based system for defining flat command line interfaces.