### PR TITLE
Try default parsing of timestamps

### DIFF
--- a/Cognite.Common/CogniteTime.cs
+++ b/Cognite.Common/CogniteTime.cs
@@ -145,7 +145,7 @@ namespace Cognite.Extractor.Common
         /// The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago'
         /// returns a timestamp two days ago.
         /// If the format is N[timeunit], without -ago, it is set to the future, or after <paramref name="relative"/>
-        /// Without timeunit, it is converted to a datetime in milliseconds since epoch.
+        /// Without timeunit, it is converted to a datetime in milliseconds since epoch, or by using a standard datetime format like ISO 8601.
         /// </summary>
         /// <param name="t">Timestamp string</param>
         /// <param name="relative">Set time relative to this if -ago syntax is used</param>
@@ -176,8 +176,11 @@ namespace Cognite.Extractor.Common
             }
             catch
             {
-                return null;
             }
+
+            if (DateTime.TryParse(t, out var result)) return result;
+
+            return null;
         }
 
         /// <summary>
@@ -212,9 +215,10 @@ namespace Cognite.Extractor.Common
                 }
                 catch
                 {
-                    return null;
                 }
             }
+
+            if (TimeSpan.TryParse(t, out var result)) return result;
 
             return null;
         }

--- a/ExtractorUtils.Test/unit/CogniteTimeTest.cs
+++ b/ExtractorUtils.Test/unit/CogniteTimeTest.cs
@@ -215,6 +215,7 @@ namespace ExtractorUtils.Test.Unit
         [InlineData("1234s-", true)]
         [InlineData("1234k", true)]
         [InlineData("1209600000ms", false)]
+        [InlineData("14.00:00:00", false)]
         public static void TestParseTimeFuture(string input, bool resultNull)
         {
             var time = DateTime.UtcNow;
@@ -253,9 +254,9 @@ namespace ExtractorUtils.Test.Unit
         [InlineData("1209600", false, "s")]
         [InlineData("1209600000ms", false)]
         [InlineData("1209600000", false, "ms")]
-        [InlineData("1234", true)]
         [InlineData("test", true, "s")]
         [InlineData("1234k", true)]
+        [InlineData("14.00:00:00", false)]
         public static void TestParseTimeSpan(string input, bool resultNull, string unit = null)
         {
             var reference = TimeSpan.FromDays(14);


### PR DESCRIPTION
This is simple and makes timestamp/timespan configuration even more flexible.