### PR TITLE
Remote config

### DIFF
--- a/Cognite.Common/Cognite.Common.csproj
+++ b/Cognite.Common/Cognite.Common.csproj
@@ -22,7 +22,7 @@
     <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.4" />
     <PackageReference Include="Cronos" Version="0.7.1" />
   </ItemGroup>
 

--- a/Cognite.Common/PeriodicScheduler.cs
+++ b/Cognite.Common/PeriodicScheduler.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -114,7 +114,7 @@ namespace Cognite.Extractor.Configuration
         /// <returns>A configuration object of type <typeparamref name="T"/></returns>
         /// <exception cref="ConfigurationException">Thrown when the version is not valid or
         /// in case of yaml parsing errors.</exception>
-        public static T TryReadConfigFromString<T>(string yaml, params int[] acceptedConfigVersions) where T : VersionedConfig
+        public static T TryReadConfigFromString<T>(string yaml, params int[]? acceptedConfigVersions) where T : VersionedConfig
         {
             int configVersion = GetVersionFromString(yaml);
             CheckVersion(configVersion, acceptedConfigVersions);
@@ -153,8 +153,25 @@ namespace Cognite.Extractor.Configuration
         /// </summary>
         /// <param name="tag">Tag to be mapped</param>
         /// <typeparam name="T">Type to map to</typeparam>
-        public static void AddTagMapping<T>(string tag) {
+        public static void AddTagMapping<T>(string tag)
+        {
             builder = builder.WithTagMapping(tag, typeof(T));
+            deserializer = builder.Build();
+        }
+
+        /// <summary>
+        /// Configures the deserializer to ignore unmatched properties.
+        /// </summary>
+        public static void IgnoreUnmatchedProperties()
+        {
+            deserializer = builder.IgnoreUnmatchedProperties().Build();
+        }
+
+        /// <summary>
+        /// Configures the deserializer to throw an exception on unmatched properties, this is the default.
+        /// </summary>
+        public static void DisallowUnmatchedProperties()
+        {
             deserializer = builder.Build();
         }
 

--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -27,6 +27,12 @@ namespace Cognite.Extractor.Configuration
             .WithNodeDeserializer(new TemplatedValueDeserializer());
         private static IDeserializer deserializer = builder
             .Build();
+        private static DeserializerBuilder ignoreUnmatchedBuilder = new DeserializerBuilder()
+            .WithNamingConvention(HyphenatedNamingConvention.Instance)
+            .WithNodeDeserializer(new TemplatedValueDeserializer())
+            .IgnoreUnmatchedProperties();
+
+        private static bool ignoreUnmatchedProperties;
 
         /// <summary>
         /// Reads the provided string containing yml and deserializes it to an object of type <typeparamref name="T"/>.
@@ -156,7 +162,15 @@ namespace Cognite.Extractor.Configuration
         public static void AddTagMapping<T>(string tag)
         {
             builder = builder.WithTagMapping(tag, typeof(T));
-            deserializer = builder.Build();
+            ignoreUnmatchedBuilder = ignoreUnmatchedBuilder.WithTagMapping(tag, typeof(T));
+            if (ignoreUnmatchedProperties)
+            {
+                deserializer = ignoreUnmatchedBuilder.Build();
+            }
+            else
+            {
+                deserializer = builder.Build();
+            }
         }
 
         /// <summary>
@@ -164,7 +178,8 @@ namespace Cognite.Extractor.Configuration
         /// </summary>
         public static void IgnoreUnmatchedProperties()
         {
-            deserializer = builder.IgnoreUnmatchedProperties().Build();
+            ignoreUnmatchedProperties = true;
+            deserializer = ignoreUnmatchedBuilder.Build();
         }
 
         /// <summary>
@@ -172,6 +187,7 @@ namespace Cognite.Extractor.Configuration
         /// </summary>
         public static void DisallowUnmatchedProperties()
         {
+            ignoreUnmatchedProperties = false;
             deserializer = builder.Build();
         }
 

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -24,11 +24,11 @@
     <ProjectReference Include="..\Cognite.Common\Cognite.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.41.0" />
-    <PackageReference Include="CogniteSdk" Version="3.1.0" />
-    <PackageReference Include="prometheus-net" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.44.0" />
+    <PackageReference Include="CogniteSdk" Version="3.4.0" />
+    <PackageReference Include="prometheus-net" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.5" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/Cognite.Logging/Cognite.Logging.csproj
+++ b/Cognite.Logging/Cognite.Logging.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/Cognite.Metrics/Cognite.Metrics.csproj
+++ b/Cognite.Metrics/Cognite.Metrics.csproj
@@ -24,9 +24,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.5" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="prometheus-net" Version="5.0.2" />
+    <PackageReference Include="prometheus-net" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExampleExtractor/Program.cs
+++ b/ExampleExtractor/Program.cs
@@ -7,13 +7,26 @@ using System;
 using System.Collections.Generic;
 using Cognite.Extractor.Utils.CommandLine;
 using System.CommandLine;
+using Cognite.Extractor.Common;
 
 class MyExtractor : BaseExtractor<BaseConfig>
 {
-    public MyExtractor(BaseConfig config, IServiceProvider provider, CogniteDestination destination, ExtractionRun run)
-        : base(config, provider, destination, run)
+    public MyExtractor(BaseConfig config, IServiceProvider provider, CogniteDestination destination, ExtractionRun run, RemoteConfigManager<BaseConfig> configManager)
+        : base(config, provider, destination, run, configManager)
     {
+        // Configure extraction pipeline
         if (run != null) run.Continuous = true;
+        // Configure extractor to check for updates to config every five minutes.
+        // Here you could also use CronTimeSpanWrapper, or TimeSpanWrapper, to let users set this through configuration.
+        if (configManager != null)
+        {
+            configManager.UpdatePeriod = new BasicTimeSpanProvider(TimeSpan.FromMinutes(5));
+            // On configuration change, tell the extractor to stop.
+            OnConfigUpdate += (sender, config, revision) =>
+            {
+                Source.Cancel();
+            };
+        }
     }
 
     protected override async Task Start()

--- a/ExampleExtractor/config.yml
+++ b/ExampleExtractor/config.yml
@@ -1,7 +1,8 @@
 version: 1
-logger:
-  console:
-    level: verbose
+#logger:
+#  console:
+#    level: verbose
+type: remote
 cognite:
   project: ${BF_TEST_PROJECT}
   host: ${BF_TEST_HOST}
@@ -11,3 +12,5 @@ cognite:
     secret: ${BF_TEST_SECRET}
     scopes:
       - ${BF_TEST_SCOPE}
+  extraction-pipeline:
+    pipeline-id: net-remote-test

--- a/ExtractorUtils.Test/CDFTester.cs
+++ b/ExtractorUtils.Test/CDFTester.cs
@@ -1,11 +1,13 @@
 ﻿using Cognite.Extractor.Testing;
 using Cognite.Extractor.Utils;
+using CogniteSdk;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace ExtractorUtils.Test
@@ -51,15 +53,37 @@ namespace ExtractorUtils.Test
         {
         }
 
-        public static string[] GetConfig(CogniteHost host)
+        public async Task<long> GetDataSetId()
         {
-            var config = new List<string>() {
-                "version: 2",
-                "logger:",
-                "  console:",
-                "    level: verbose",
-                "cognite:",
-            };
+
+            var dataSets = await Destination.CogniteClient.DataSets.RetrieveAsync(new[] { "test-dataset" }, true);
+            if (!dataSets.Any())
+            {
+                dataSets = await Destination.CogniteClient.DataSets.CreateAsync(new[] { new DataSetCreate
+                {
+                    Description = ".NET utils test dataset",
+                    ExternalId = "test-dataset",
+                    Name = "Test dataset"
+                } });
+            }
+            return dataSets.First().Id;
+        }
+
+        public static string[] GetConfig(CogniteHost host, bool onlyCognite = false)
+        {
+            var config = onlyCognite
+                ? new List<string>()
+                {
+                    "version: 2",
+                    "cognite:"
+                }
+                : new List<string>() {
+                    "version: 2",
+                    "logger:",
+                    "  console:",
+                    "    level: verbose",
+                    "cognite:",
+                };
             switch (host)
             {
                 case CogniteHost.GreenField:

--- a/ExtractorUtils.Test/ExtractorUtils.Test.csproj
+++ b/ExtractorUtils.Test/ExtractorUtils.Test.csproj
@@ -5,9 +5,9 @@
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ExtractorUtils\ExtractorUtils.csproj" />

--- a/ExtractorUtils.Test/integration/ExtractorTest.cs
+++ b/ExtractorUtils.Test/integration/ExtractorTest.cs
@@ -1,4 +1,5 @@
 ﻿using Cognite.Extensions;
+using Cognite.Extractor.Testing;
 using Cognite.Extractor.Utils;
 using CogniteSdk;
 using Microsoft.Extensions.DependencyInjection;
@@ -144,10 +145,10 @@ namespace ExtractorUtils.Test.Integration
         }
     }
 
-    public class ExtractorTest
+    public class ExtractorTest : ConsoleWrapper
     {
         private readonly ITestOutputHelper _output;
-        public ExtractorTest(ITestOutputHelper output)
+        public ExtractorTest(ITestOutputHelper output) : base(output)
         {
             _output = output;
         }
@@ -335,6 +336,7 @@ namespace ExtractorUtils.Test.Integration
         {
             var cfg = new MyConfig();
             cfg.GenerateDefaults();
+            cfg.Logger.Console = new Cognite.Extractor.Logging.ConsoleConfig { Level = "debug" };
 
             NoCdfExtractor ext = null;
 
@@ -363,6 +365,11 @@ namespace ExtractorUtils.Test.Integration
                 );
 
             await Task.Delay(500);
+
+            if (task.IsFaulted)
+            {
+                throw task.Exception;
+            }
 
             Assert.NotNull(ext);
             Assert.True(ext.Started);

--- a/ExtractorUtils.Test/integration/RemoteConfigTest.cs
+++ b/ExtractorUtils.Test/integration/RemoteConfigTest.cs
@@ -1,0 +1,127 @@
+﻿using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using CogniteSdk;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ExtractorUtils.Test.integration
+{
+    public class RemoteConfigTest
+    {
+        private readonly ITestOutputHelper _output;
+        public RemoteConfigTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private async Task<ExtPipe> Setup(CDFTester tester)
+        {
+            var pipeline = (await tester.Destination.CogniteClient.ExtPipes.CreateAsync(new[] { new ExtPipeCreate
+            {
+                DataSetId = await tester.GetDataSetId(),
+                ExternalId = $"{tester.Prefix}-config-extpipe-1",
+                Name = "Config test extpipe"
+            } })).First();
+            return pipeline;
+        }
+
+        private void WriteConfig(CogniteHost host, bool remote, string path, string pipelineId)
+        {
+            var lines = CDFTester.GetConfig(host, true);
+            lines = lines.Prepend($"type: {(remote ? "remote" : "local")}").Append("  extraction-pipeline:").Append($"    pipeline-id: {pipelineId}").ToArray();
+            System.IO.File.WriteAllLines(path, lines);
+        }
+
+        [Theory]
+        // [InlineData(CogniteHost.GreenField)]
+        [InlineData(CogniteHost.BlueField)]
+        public async Task TestRemoteConfigDI(CogniteHost host)
+        {
+            var tester = new CDFTester(host, _output);
+            var localConfigPath = $"{tester.Prefix}-local-config.yml";
+            var remoteConfigPath = $"{tester.Prefix}-remote-config.yml";
+            var pipeline = await Setup(tester);
+            WriteConfig(host, false, localConfigPath, pipeline.ExternalId);
+            WriteConfig(host, true, remoteConfigPath, pipeline.ExternalId);
+            try
+            {
+                var services = new ServiceCollection();
+                // Should just load local config
+                var config = await services.AddRemoteConfig<BaseConfig>(null, localConfigPath, null, "utils-test-app", null, true, false, null, tester.Source.Token, 2);
+                Assert.Equal(tester.Config.Cognite.Project, config.Cognite.Project);
+                var provider = services.BuildServiceProvider();
+                Assert.Null(provider.GetService<RemoteConfigManager<BaseConfig>>());
+
+                // Should fail because there is no remote config
+                services = new ServiceCollection();
+                await Assert.ThrowsAsync<ConfigurationException>(async () => await services.AddRemoteConfig<BaseConfig>(null, remoteConfigPath, null, "utils-test-app", null, true, false, null, tester.Source.Token, 2));
+
+                // Create a remote config, then try again
+                await tester.Destination.CogniteClient.Playground.ExtPipeConfigs.Create(new ExtPipeConfigCreate
+                {
+                    Config = "{\"version\": 2, \"logger\": { \"console\": {\"level\": \"verbose\"}}}",
+                    ExternalId = pipeline.ExternalId
+                });
+                services = new ServiceCollection();
+                config = await services.AddRemoteConfig<BaseConfig>(null, remoteConfigPath, null, "utils-test-app", null, true, false, null, tester.Source.Token, 2);
+                Assert.Equal("verbose", config.Logger.Console.Level);
+                Assert.Equal(tester.Config.Cognite.Project, config.Cognite.Project);
+
+                // Pass the remote config in, this could be useful for creating extractors that just always pull configuration from env
+                var localCognite = new CogniteConfig
+                {
+                    ApiKey = tester.Config.Cognite.ApiKey,
+                    Project = tester.Config.Cognite.Project,
+                    IdpAuthentication = tester.Config.Cognite.IdpAuthentication,
+                    Host = tester.Config.Cognite.Host,
+                    ExtractionPipeline = new ExtractionRunConfig
+                    {
+                        PipelineId = pipeline.ExternalId
+                    }
+                };
+                services = new ServiceCollection();
+                config = await services.AddRemoteConfig<BaseConfig>(null, null, null, "utils-test-app", null, true, false, new RemoteConfig
+                {
+                    Cognite = localCognite,
+                    Version = 2,
+                    Type = ConfigurationMode.Remote
+                }, tester.Source.Token, 2);
+                Assert.Equal("verbose", config.Logger.Console.Level);
+                Assert.Equal(tester.Config.Cognite.Project, config.Cognite.Project);
+
+                // Pass the remote config in as local, but no path, which should fail
+                
+                services = new ServiceCollection();
+                await Assert.ThrowsAsync<ConfigurationException>(async () => await services.AddRemoteConfig<BaseConfig>(null, null, null, "utils-test-app", null, true, false, new RemoteConfig
+                {
+                    Cognite = localCognite,
+                    Version = 2,
+                    Type = ConfigurationMode.Local
+                }, tester.Source.Token, 2));
+
+                // Try again, this time passing path
+                services = new ServiceCollection();
+                config = await services.AddRemoteConfig<BaseConfig>(null, localConfigPath, null, "utils-test-app", null, true, false, new RemoteConfig
+                {
+                    Cognite = localCognite,
+                    Version = 2,
+                    Type = ConfigurationMode.Local
+                }, tester.Source.Token, 2);
+                Assert.Null(config.Logger.Console);
+                Assert.Equal(tester.Config.Cognite.Project, config.Cognite.Project);
+            }
+            finally
+            {
+                await tester.Destination.CogniteClient.ExtPipes.DeleteAsync(new[] { pipeline.Id });
+                System.IO.File.Delete(localConfigPath);
+                System.IO.File.Delete(remoteConfigPath);
+            }
+        }
+    }
+}

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -14,6 +14,9 @@ namespace Cognite.Extractor.Utils
     /// </summary>
     public class BaseConfig : VersionedConfig
     {
+        /// <summary>
+        /// Type of configuration this represents, local or remote. Will generally always be local.
+        /// </summary>
         public ConfigurationMode Type { get; set; } = ConfigurationMode.Local;
         /// <summary>
         /// Logging configuration (optional)

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Cognite.Extractor.Utils
 {
-
     /// <summary>
     /// Base configuration object for extractors.
     /// The config should have a version property, so that versioning and compatibility can be tracked by the extractor.
@@ -52,7 +51,6 @@ namespace Cognite.Extractor.Utils
     }
 
     #region Cognite configuration
-
     /// <summary>
     /// Cognite configuration object
     /// </summary>

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -14,7 +14,7 @@ namespace Cognite.Extractor.Utils
     /// </summary>
     public class BaseConfig : VersionedConfig
     {
-
+        public ConfigurationMode Type { get; set; } = ConfigurationMode.Local;
         /// <summary>
         /// Logging configuration (optional)
         /// </summary>

--- a/ExtractorUtils/Configuration/RemoteConfig.cs
+++ b/ExtractorUtils/Configuration/RemoteConfig.cs
@@ -1,0 +1,148 @@
+﻿using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cognite.Extractor.Utils
+{
+    /// <summary>
+    /// Whether configuration is read from CDF or stored locally.
+    /// </summary>
+    public enum ConfigurationMode
+    {
+        /// <summary>
+        /// Config file is read locally.
+        /// </summary>
+        Local,
+        /// <summary>
+        /// Config file is remote.
+        /// </summary>
+        Remote
+    }
+
+    /// <summary>
+    /// Configuration object used locally when config files are read from CDF.
+    /// </summary>
+    public class RemoteConfig : VersionedConfig
+    {
+        /// <summary>
+        /// Configuration type
+        /// </summary>
+        public ConfigurationMode Type { get; set; } = ConfigurationMode.Local;
+
+        /// <summary>
+        /// Cognite configuration object.
+        /// </summary>
+        public CogniteConfig CogniteConfig { get; set; } = null!;
+
+        /// <inheritdoc />
+        public override void GenerateDefaults()
+        {
+            CogniteConfig = new CogniteConfig();
+        }
+    }
+
+    /// <summary>
+    /// Class to handle fetching of remote config objects.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class RemoteConfigManager<T> where T : VersionedConfig
+    {
+        private int _currentRevision;
+        private CogniteDestination _destination;
+        private string? _bufferFilePath;
+        private int[]? _acceptedConfigVersions;
+        private string _pipelineId;
+        private ILogger<RemoteConfigManager<T>> _logger;
+        /// <summary>
+        /// Current configuration object, if fetched.
+        /// </summary>
+        public T? Config { get; private set; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="destination">Cognite destination to use to fetch data from CDF.</param>
+        /// <param name="configFilePath">Path to local config file, used for buffering.</param>
+        /// <param name="bufferConfigFile">True to buffer the config file.</param>
+        /// <param name="acceptedConfigVersions">List of accepted values of the "version" parameter, or null.</param>
+        /// <param name="logger">Logger to use</param>
+        /// <param name="pipelineId">Extraction pipeline id</param>
+        public RemoteConfigManager(CogniteDestination destination, ILogger<RemoteConfigManager<T>>? logger, string configFilePath, bool bufferConfigFile, int[]? acceptedConfigVersions, string pipelineId)
+        {
+            _destination = destination;
+            _bufferFilePath = bufferConfigFile ? $"{Path.GetDirectoryName(configFilePath)}/_temp_{Path.GetFileName(configFilePath)}" : null;
+            _acceptedConfigVersions = acceptedConfigVersions;
+            _pipelineId = pipelineId;
+            _logger = logger ?? new NullLogger<RemoteConfigManager<T>>();
+        }
+
+        private async Task<(T config, int revision)> FetchLatestInternal(CancellationToken token)
+        {
+            try
+            {
+                var rawConfig = await _destination.CogniteClient.Playground.ExtPipeConfigs.GetCurrentConfig(_pipelineId, token).ConfigureAwait(false);
+                var config = ConfigurationUtils.TryReadConfigFromString<T>(rawConfig.Config, _acceptedConfigVersions);
+
+                if (_bufferFilePath != null)
+                {
+                    File.WriteAllText(_bufferFilePath, rawConfig.Config);
+                }
+
+                Config = config;
+
+                return (config, rawConfig.Revision);
+            }
+            catch (Exception ex)
+            {
+                if (Config == null && _bufferFilePath != null)
+                {
+                    if (!File.Exists(_bufferFilePath)) throw new ConfigurationException($"Could not retrieve remote configuration, and local buffer does not exist: {ex.Message}", ex);
+                    return (ConfigurationUtils.TryReadConfigFromFile<T>(_bufferFilePath, _acceptedConfigVersions), 0);
+                }
+                else if (Config != null)
+                {
+                    return (Config, _currentRevision);
+                }
+                throw new ConfigurationException($"Could not retrieve remote configuration: {ex.Message}", ex);
+            }
+        }
+
+        internal async Task<T> FetchLatestThrowOnFailure(CancellationToken token)
+        {
+            var (config, revision) = await FetchLatestInternal(token).ConfigureAwait(false);
+            _currentRevision = revision;
+            return config;
+        }
+
+        /// <summary>
+        /// Fetch latest configuration file from CDF.
+        /// </summary>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>The new configuration object if one was found. If none was found or the revision number was unchanged, this returns null.</returns>
+        public async Task<T?> FetchLatest(CancellationToken token)
+        {
+            try
+            {
+                var (config, revision) = await FetchLatestInternal(token).ConfigureAwait(false);
+                if (revision == _currentRevision || revision == 0)
+                {
+                    return null;
+                }
+                _currentRevision = revision;
+                return config;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Failed to fetch latest configuration file from CDF: {Message}", ex.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -106,7 +106,7 @@ namespace Cognite.Extractor.Utils
         /// <summary>
         /// Allow users to set type: remote and fetch config from extraction pipelines.
         /// </summary>
-        public bool AllowRemoteConfig { get; set; }
+        public bool AllowRemoteConfig { get; set; } = true;
         /// <summary>
         /// True to buffer config if it is fetched from remote. Requires a config path to be set.
         /// Defaults to true.

--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -245,7 +245,8 @@ namespace Cognite.Extractor.Utils
                 ConfigurationException? exception = null;
                 try
                 {
-                    if (options.AllowRemoteConfig)
+                    bool usesRemoteConfig = false;
+                    if (options.AllowRemoteConfig && options.Config == null)
                     {
                         options.Config = await services.AddRemoteConfig<TConfig>(
                             options.StartupLogger,
@@ -258,6 +259,7 @@ namespace Cognite.Extractor.Utils
                             options.RemoteConfig,
                             token,
                             options.AcceptedConfigVersions).ConfigureAwait(false);
+                        usesRemoteConfig = true;
                     }
 
 
@@ -273,7 +275,7 @@ namespace Cognite.Extractor.Utils
                         options.Config,
                         options.BuildLogger,
                         options.ConfigTypes,
-                        options.AllowRemoteConfig);
+                        doNotAddConfig: usesRemoteConfig);
                     options.ConfigCallback?.Invoke(options.Config, options, services);
                 }
                 catch (TargetInvocationException ex)

--- a/ExtractorUtils/ExtractorUtils.csproj
+++ b/ExtractorUtils/ExtractorUtils.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
   </ItemGroup>


### PR DESCRIPTION
Support for remote configuration files in the .NET extractor utils.

As demonstrated in the ExampleExtractor, this can be quite simple to use: just inject it optionally in the constructor, then pass it to BaseExtractor, and optionally configure it to refresh with a fixed period.

Unlike the python utils, we make no attempts at handling new detected configuration files, beyond triggering an event, which can stop the extractor or make some other extractor specific change.

The _volume_ of code is unfortunately quite large, just because this feature is involved in many parts of the framework.