### PR TITLE
Remove verification of datapoint deletes

### DIFF
--- a/Cognite.Extensions/DeleteError.cs
+++ b/Cognite.Extensions/DeleteError.cs
@@ -14,7 +14,8 @@ namespace Cognite.Extensions
         public IEnumerable<Identity> IdsNotFound { get; }
         
         /// <summary>
-        /// Ids of time series with unconfirmed data point deletions
+        /// Ids of time series with unconfirmed data point deletions.
+        /// DEPRECATED, timeseries is now immediately consistent, and we no longer verify deletion.
         /// </summary>
         public IEnumerable<Identity> IdsDeleteNotConfirmed { get; }
 
@@ -23,7 +24,7 @@ namespace Cognite.Extensions
         /// found or with unconfirmed deletions
         /// </summary>
         /// <param name="idsNotFound">Ids not found</param>
-        /// <param name="idsDeleteNotConfirmed">Mismatched ids</param>
+        /// <param name="idsDeleteNotConfirmed">Mismatched ids. DEPRECATED, leave empty.</param>
         public DeleteError(IEnumerable<Identity> idsNotFound, IEnumerable<Identity> idsDeleteNotConfirmed)
         {
             IdsNotFound = idsNotFound;

--- a/ExtractorUtils.Test/unit/DatapointsTest.cs
+++ b/ExtractorUtils.Test/unit/DatapointsTest.cs
@@ -175,7 +175,7 @@ namespace ExtractorUtils.Test.Unit
                 mockHttpMessageHandler.Protected()
                 .Verify<Task<HttpResponseMessage>>(
                     "SendAsync", 
-                    Times.Exactly(3), // 1 delete and two list
+                    Times.Exactly(1), // 1 delete
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>());
 
@@ -195,8 +195,6 @@ namespace ExtractorUtils.Test.Unit
                 
                 Assert.Contains(new Identity("missing-C"), errors.IdsNotFound);
                 Assert.Contains(new Identity("missing-F"), errors.IdsNotFound);
-                Assert.Contains(new Identity("nc-E"), errors.IdsDeleteNotConfirmed);
-                Assert.Contains(new Identity("nc-H"), errors.IdsDeleteNotConfirmed);
             }
 
             System.IO.File.Delete(path);
@@ -565,10 +563,6 @@ namespace ExtractorUtils.Test.Unit
                     var dp = new DataPointListItem();
                     dp.ExternalId = id;
                     dp.NumericDatapoints = new NumericDatapoints();
-                    if (id.StartsWith("nc"))
-                    {
-                        dp.NumericDatapoints.Datapoints.Add(new NumericDatapoint{Timestamp = DateTime.UtcNow.ToUnixTimeMilliseconds(), Value = 1.0});
-                    }
                     dpList.Items.Add(dp);
                 }
                 using(MemoryStream stream = new MemoryStream())


### PR DESCRIPTION
We once needed this, since timeseries were not immediately consistent, but that is no longer the case, and this adds additional complexity that we don't need.