### PR TITLE
Improve HA startup time

### DIFF
--- a/Cognite.Common/HighAvailability.cs
+++ b/Cognite.Common/HighAvailability.cs
@@ -45,7 +45,7 @@ namespace Cognite.Extractor.Common
         /// <summary>
         /// State of the current extractors.
         /// </summary>
-        public List<IExtractorInstance> CurrentState { get; set; }
+        public Dictionary<int, IExtractorInstance> CurrentState { get; set; }
 
         /// <summary>
         /// Value used by the extractor to update its own active status.
@@ -58,7 +58,7 @@ namespace Cognite.Extractor.Common
         /// <param name="initialStatus">The initial active status of the extractor.</param>
         public ExtractorState(bool initialStatus = false)
         {
-            CurrentState = new List<IExtractorInstance>();
+            CurrentState = new Dictionary<int, IExtractorInstance>();
             UpdatedStatus = initialStatus;
         }
     }

--- a/ExtractorUtils.Test/unit/RawHighAvailabilityTest.cs
+++ b/ExtractorUtils.Test/unit/RawHighAvailabilityTest.cs
@@ -131,16 +131,17 @@ namespace ExtractorUtils.Test.Unit
 
                 Assert.True(extractorManager._state.CurrentState.Count == 0);
 
+                await extractorManager.UploadLogToState();
                 await extractorManager.UpdateExtractorState();
 
                 // Testing that the state has changed.
-                Assert.True(extractorManager._state.CurrentState.Count == 4);
+                Assert.Equal(4, extractorManager._state.CurrentState.Count);
 
                 // Checking that each value in the state is the same as in the db.
                 foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
                 {
                     string key = instance.Index.ToString();
-                    if (rows.ContainsKey(key))
+                    if (rows.ContainsKey(key) && key != "0")
                     {
                         Assert.True(rows[key].Active == instance.Active);
                         Assert.True(rows[key].TimeStamp == instance.TimeStamp);
@@ -151,6 +152,7 @@ namespace ExtractorUtils.Test.Unit
                 string testKey = "1";
                 rows[testKey] = new RawLogData(DateTime.UtcNow, true);
 
+                await extractorManager.UploadLogToState();
                 await extractorManager.UpdateExtractorState();
 
                 foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
@@ -170,6 +172,7 @@ namespace ExtractorUtils.Test.Unit
                 RawLogData logCopy = rows[testKey];
                 rows.Remove(testKey);
 
+                await extractorManager.UploadLogToState();
                 await extractorManager.UpdateExtractorState();
 
                 // Checking that the state still has all the rows.
@@ -189,6 +192,7 @@ namespace ExtractorUtils.Test.Unit
                 // Inserting the removed extractor back and checking that the new value is used again.
                 rows[testKey] = new RawLogData(DateTime.UtcNow, false);
 
+                await extractorManager.UploadLogToState();
                 await extractorManager.UpdateExtractorState();
 
                 foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
@@ -207,6 +211,7 @@ namespace ExtractorUtils.Test.Unit
                 testKey = "3";
                 rows[testKey] = new RawLogData(DateTime.UtcNow, !rows[testKey].Active);
 
+                await extractorManager.UploadLogToState();
                 await extractorManager.UpdateExtractorState();
 
                 foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)

--- a/ExtractorUtils.Test/unit/RawHighAvailabilityTest.cs
+++ b/ExtractorUtils.Test/unit/RawHighAvailabilityTest.cs
@@ -14,6 +14,7 @@ using Cognite.Extractor.Utils;
 using Cognite.Extractor.Testing;
 using Cognite.Extractor.Common;
 using CogniteSdk;
+using System.Linq;
 
 namespace ExtractorUtils.Test.Unit
 {
@@ -136,7 +137,7 @@ namespace ExtractorUtils.Test.Unit
                 Assert.True(extractorManager._state.CurrentState.Count == 4);
 
                 // Checking that each value in the state is the same as in the db.
-                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState)
+                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
                 {
                     string key = instance.Index.ToString();
                     if (rows.ContainsKey(key))
@@ -152,7 +153,7 @@ namespace ExtractorUtils.Test.Unit
 
                 await extractorManager.UpdateExtractorState();
 
-                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState)
+                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
                 {
                     if (instance.Index == Int16.Parse(testKey))
                     {
@@ -174,7 +175,7 @@ namespace ExtractorUtils.Test.Unit
                 // Checking that the state still has all the rows.
                 Assert.True(extractorManager._state.CurrentState.Count == 4);
 
-                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState)
+                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
                 {
                     if (instance.Index == Int16.Parse(testKey))
                     {
@@ -190,7 +191,7 @@ namespace ExtractorUtils.Test.Unit
 
                 await extractorManager.UpdateExtractorState();
 
-                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState)
+                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
                 {
                     if (instance.Index == Int16.Parse(testKey))
                     {
@@ -208,7 +209,7 @@ namespace ExtractorUtils.Test.Unit
 
                 await extractorManager.UpdateExtractorState();
 
-                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState)
+                foreach (RawExtractorInstance instance in extractorManager._state.CurrentState.Values)
                 {
                     if (instance.Index == Int16.Parse(testKey))
                     {
@@ -246,7 +247,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow, true));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 50)), false));
 
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
                 extractorManager.CheckForMultipleActiveExtractors();
 
                 // Extractor 1 will be cancelled because both 0 and 1 are active, where 0 has higher priority.
@@ -260,7 +261,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 20)), true));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 50)), true));
 
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
                 extractorManager.CheckForMultipleActiveExtractors();
 
                 // Extractor 1 will not be cancelled because it is not active.
@@ -274,7 +275,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow, true));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow, true));
 
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
                 extractorManager.CheckForMultipleActiveExtractors();
 
                 // Extractor 1 will be cancelled because there are multiple active extractors and 0 has higher priority.
@@ -288,7 +289,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow, true));
                 extractorInstances.Add(new RawExtractorInstance(3, DateTime.UtcNow, true));
 
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
                 extractorManager.CheckForMultipleActiveExtractors();
 
                 // Extractor 1 will not be cancelled because it has higher priority than 2 and 3.
@@ -320,7 +321,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow, false));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 30)), false));
                 extractorInstances.Add(new RawExtractorInstance(3, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 30)), false));
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
 
                 // Extractor 1 will become active because 2 and 3 are not within the time threshold.
                 Assert.True(extractorManager.ShouldBecomeActive());
@@ -329,7 +330,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow, false));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow, true));
                 extractorInstances.Add(new RawExtractorInstance(3, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 30)), false));
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
 
                 // Extractor 1 will not become active because 2 is already active and within the time threshold.
                 Assert.False(extractorManager.ShouldBecomeActive());
@@ -338,7 +339,7 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow, false));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 30)), true));
                 extractorInstances.Add(new RawExtractorInstance(3, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 30)), true));
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
 
                 // Extractor 1 will become active because 2 and 3 are over the time threshold.
                 Assert.True(extractorManager.ShouldBecomeActive());
@@ -347,13 +348,13 @@ namespace ExtractorUtils.Test.Unit
                 extractorInstances.Add(new RawExtractorInstance(0, DateTime.UtcNow, false));
                 extractorInstances.Add(new RawExtractorInstance(1, DateTime.UtcNow, false));
                 extractorInstances.Add(new RawExtractorInstance(2, DateTime.UtcNow.Subtract(new TimeSpan(0, 0, 30)), true));
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
 
                 // Extractor 1 will not become active because 0 has higher priority.
                 Assert.False(extractorManager.ShouldBecomeActive());
 
                 extractorInstances.Clear();
-                extractorManager._state.CurrentState = extractorInstances;
+                extractorManager._state.CurrentState = extractorInstances.ToDictionary(ex => ex.Index);
 
                 // Extractor 1 will not become active because the state is empty.
                 Assert.False(extractorManager.ShouldBecomeActive());

--- a/ExtractorUtils/HighAvailability/RawHighAvailabilityManager.cs
+++ b/ExtractorUtils/HighAvailability/RawHighAvailabilityManager.cs
@@ -42,7 +42,7 @@ namespace Cognite.Extractor.Utils
         internal override async Task UploadLogToState()
         {
             var now = DateTime.UtcNow;
-            var log = new RawLogData(DateTime.UtcNow, _state.UpdatedStatus);
+            var log = new RawLogData(now, _state.UpdatedStatus);
             var state = new RawExtractorInstance(_config.Index, now, _state.UpdatedStatus);
 
             _state.CurrentState[_config.Index] = state;


### PR DESCRIPTION
It takes a bit long now, there are two reasons:
 - Instead of reusing uploaded state, we re-download the state and use that, which may be outdated.
 - We wait on startup, unnecessarily.