### PR TITLE
Add alias for pipeline-id, to align with python utils

### DIFF
--- a/ExtractorUtils/ExtractionRun.cs
+++ b/ExtractorUtils/ExtractionRun.cs
@@ -15,14 +15,26 @@ namespace Cognite.Extractor.Utils
     /// </summary>
     public class ExtractionRunConfig
     {
+        private string? _pipelineId;
         /// <summary>
         /// ExternalId of extraction pipeline.
         /// </summary>
-        public string? PipelineId { get; set; }
+        public string? PipelineId
+        {
+            get => _pipelineId;
+            set => _pipelineId = value;
+        }
         /// <summary>
         /// Frequency of extraction pipeline updates in seconds.
         /// </summary>
         public int Frequency { get; set; } = 600;
+        /// <summary>
+        /// Extraction pipeline external id
+        /// </summary>
+        public string? ExternalId
+        {
+            set => _pipelineId = value;
+        }
     }
 
     /// <summary>

--- a/ExtractorUtils/config/config.example.yml
+++ b/ExtractorUtils/config/config.example.yml
@@ -111,7 +111,7 @@ cognite:
     # Configure an extraction pipeline manager
     extraction-pipeline:
         # ExternalId of extraction pipeline
-        # pipeline-id: 
+        # external-id: 
         # Frequency to report "Seen", in seconds. Less than or equal to zero will not report automatically.
         # frequency: 600
 


### PR DESCRIPTION
It is now possible to create a single common base config file for remote python and .NET extractors.