### PR TITLE
feat: automatic authenticator implied

### DIFF
--- a/Cognite.Extensions/Authenticator.cs
+++ b/Cognite.Extensions/Authenticator.cs
@@ -163,20 +163,7 @@ namespace Cognite.Extensions
             _client = client;
             _logger = logger ?? new Microsoft.Extensions.Logging.Abstractions.NullLogger<Authenticator>();
 
-            if (!string.IsNullOrWhiteSpace(config.TokenUrl))
-            {
-                _tokenUri = new Uri(config.TokenUrl);
-            }
-            else if (!string.IsNullOrWhiteSpace(config.Authority))
-            {
-                var uriBuilder = new UriBuilder(_config.Authority);
-                uriBuilder.Path = $"{_config.Tenant}/oauth2/v2.0/token";
-                _tokenUri = uriBuilder.Uri;
-            }
-            else
-            {
-                throw new ConfigurationException("No OIDC tenant or token url defined");
-            }
+            _tokenUri = new Uri(config.TokenUrl);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007: Do not directly await a Task", Justification = "Awaiter configured by the caller")]

--- a/ExtractorUtils.Test/integration/AuthIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/AuthIntegrationTest.cs
@@ -50,7 +50,6 @@ namespace ExtractorUtils.Test.Integration
 
                 var configList = new List<string>(CDFTester.GetConfig(host));
                 configList.Insert(13, "    implementation: basic");
-                configList.Insert(14, "    token-url: https://login.microsoftonline.com/${BF_TEST_TENANT}/oauth2/v2.0/token");
                 var configBasic = configList.ToArray();
                 using (var tester = new CDFTester(configBasic, _output))
                 {

--- a/ExtractorUtils.Test/unit/CogniteTest.cs
+++ b/ExtractorUtils.Test/unit/CogniteTest.cs
@@ -13,7 +13,6 @@ using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
 using Xunit;
-using Cognite.Extractor.Logging;
 using Cognite.Extractor.Utils;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -51,7 +50,7 @@ namespace ExtractorUtils.Test.Unit
                                 "  idp-authentication:",
                                 "    implementation: Basic",
                                $"    client-id: {clientId}",
-                               $"    tenant: {_authTenant}",
+                                "    token-url: http://example.url/token",
                                 "    secret: thisIsASecret",
                                 "    scopes: ",
                                 "      - thisIsAScope",
@@ -670,7 +669,7 @@ namespace ExtractorUtils.Test.Unit
         private static Task<HttpResponseMessage> mockAuthSendAsync(HttpRequestMessage message, CancellationToken token)
         {
             // Verify endpoint and method
-            Assert.Equal($@"https://login.microsoftonline.com/{_authTenant}/oauth2/v2.0/token", message.RequestUri.ToString());
+            Assert.Equal($@"http://example.url/token", message.RequestUri.ToString());
             Assert.Equal(HttpMethod.Post, message.Method);
 
             if (_tokenCounter == 2) //third call fails

--- a/ExtractorUtils/Cognite/DestinationUtils.cs
+++ b/ExtractorUtils/Cognite/DestinationUtils.cs
@@ -250,12 +250,6 @@ namespace Cognite.Extractor.Utils
                     "Cannot configure Builder: Only either of 'idp-authentication.tenant' or 'idp-authentication.token-url' can be set"
                 );
             }
-            else if (String.IsNullOrWhiteSpace(_tenant) && String.IsNullOrWhiteSpace(_tokenUrl))
-            {
-                throw new CogniteUtilsException(
-                    "Cannot configure Builder: Either one of 'idp-authentication.tenant' or 'idp-authentication.token-url' has to be set"
-                );
-            }
             else if (!String.IsNullOrWhiteSpace(_tenant) && String.IsNullOrWhiteSpace(config.IdpAuthentication?.Authority))
             {
                 throw new CogniteUtilsException(

--- a/ExtractorUtils/Cognite/DestinationUtils.cs
+++ b/ExtractorUtils/Cognite/DestinationUtils.cs
@@ -247,7 +247,7 @@ namespace Cognite.Extractor.Utils
             if (!(tenant is null) && !(tokenUrl is null))
             {
                 throw new CogniteUtilsException(
-                    "Cannot configure Builder: Only either 'idp-authentication.tenant' or 'idp-authentication.token-url' can be set"
+                    "Cannot configure Builder: Only one of 'idp-authentication.tenant' or 'idp-authentication.token-url' can be set"
                 );
             }
             else if (!(tenant is null) && config.IdpAuthentication?.Authority is null)

--- a/ExtractorUtils/Cognite/DestinationUtils.cs
+++ b/ExtractorUtils/Cognite/DestinationUtils.cs
@@ -247,7 +247,7 @@ namespace Cognite.Extractor.Utils
             if (!String.IsNullOrWhiteSpace(_tenant) && !String.IsNullOrWhiteSpace(_tokenUrl))
             {
                 throw new CogniteUtilsException(
-                    "Cannot configure Builder: Only either of 'idp-authentication.tenant' or 'idp-authentication.token-url' can be set"
+                    "Cannot configure Builder: Only either 'idp-authentication.tenant' or 'idp-authentication.token-url' can be set"
                 );
             }
             else if (!String.IsNullOrWhiteSpace(_tenant) && String.IsNullOrWhiteSpace(config.IdpAuthentication?.Authority))

--- a/ExtractorUtils/Cognite/DestinationUtils.cs
+++ b/ExtractorUtils/Cognite/DestinationUtils.cs
@@ -241,19 +241,19 @@ namespace Cognite.Extractor.Utils
                 throw new CogniteUtilsException("Cannot configure Builder: Project is not configured");
             }
 
-            string? _tenant = config.IdpAuthentication?.Tenant.TrimToNull();
-            string? _tokenUrl = config.IdpAuthentication?.TokenUrl.TrimToNull();
+            string? tenant = config.IdpAuthentication?.Tenant.TrimToNull();
+            string? tokenUrl = config.IdpAuthentication?.TokenUrl.TrimToNull();
 
-            if (!String.IsNullOrWhiteSpace(_tenant) && !String.IsNullOrWhiteSpace(_tokenUrl))
+            if (!(tenant is null) && !(tokenUrl is null))
             {
                 throw new CogniteUtilsException(
                     "Cannot configure Builder: Only either 'idp-authentication.tenant' or 'idp-authentication.token-url' can be set"
                 );
             }
-            else if (!String.IsNullOrWhiteSpace(_tenant) && String.IsNullOrWhiteSpace(config.IdpAuthentication?.Authority))
+            else if (!(tenant is null) && config.IdpAuthentication?.Authority is null)
             {
                 throw new CogniteUtilsException(
-                    "Cannot configure Builder: The 'idp-authentication.authority' is required when 'idp-authentication.tenant' is provided"
+                    "Cannot configure Builder: 'idp-authentication.authority' is required when 'idp-authentication.tenant' is provided"
                 );
             }
 

--- a/ExtractorUtils/config/config.example.yml
+++ b/ExtractorUtils/config/config.example.yml
@@ -32,12 +32,6 @@ cognite:
         #   - scopeA
         #   - scopeB
         scopes:
-        # Which implementation to use in the authenticator. One of
-        # MSAL (recommended) - Microsoft Authentication Library, Works only with authority/tenant
-        # Basic - Post to authentication endpoint and parse JSON response, works with both authority/tenant and token-url
-        # Default is MSAL
-        # Deprecated: implementation is implied based on either token-url or tenant
-        implementation: MSAL
         # Audience
         audience:
         # Minimum time-to-live in seconds for the token (optional)

--- a/ExtractorUtils/config/config.example.yml
+++ b/ExtractorUtils/config/config.example.yml
@@ -36,9 +36,10 @@ cognite:
         # MSAL (recommended) - Microsoft Authentication Library, Works only with authority/tenant
         # Basic - Post to authentication endpoint and parse JSON response, works with both authority/tenant and token-url
         # Default is MSAL
-        audience:
-        # Audience
+        # Deprecated: implementation is implied based on either token-url or tenant
         implementation: MSAL
+        # Audience
+        audience:
         # Minimum time-to-live in seconds for the token (optional)
         min-ttl: 30
     # Configure automatic retries on requests to CDF. Can be left out to keep default values.


### PR DESCRIPTION
This ensures that any config with `tenant` set will always use the `MSALAuthenticator` and that with `token-url` will use the basic `Authenticator` implementation. This renders `idp-authentication.implementation` deprecated.