### PR TITLE
Schema

### DIFF
--- a/ExampleExtractor/config.yml
+++ b/ExampleExtractor/config.yml
@@ -13,9 +13,12 @@ cognite:
     scopes:
       - ${BF_TEST_SCOPE}
   extraction-pipeline:
-    pipeline-id: net-remote-test
+    external-id: net-remote-test
 high-availability:
   index: 1
   raw:
     database-name: ${BF_TEST_DB}
     table-name: ${BF_TEST_TABLE}
+logger:
+  console:
+    level: debug

--- a/ExampleExtractor/config.yml
+++ b/ExampleExtractor/config.yml
@@ -2,7 +2,7 @@ version: 1
 #logger:
 #  console:
 #    level: verbose
-type: remote
+type: local
 cognite:
   project: ${BF_TEST_PROJECT}
   host: ${BF_TEST_HOST}

--- a/ExampleExtractor/full_config.schema.json
+++ b/ExampleExtractor/full_config.schema.json
@@ -1,0 +1,10 @@
+{
+    "$id": "/dotnet/ExampleExtractor/full_config.schema.json",
+    "type": "object",
+    "allOf": [{ "$ref": "../schema/base_config.schema.json" }],
+    "properties": {
+        "high-availability": {
+            "$ref": "../schema/high_availability.schema.json"
+        }
+    }
+}

--- a/ExampleExtractor/full_config.schema.json
+++ b/ExampleExtractor/full_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/ExampleExtractor/full_config.schema.json",
+    "$id": "/ExampleExtractor/full_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "allOf": [{ "$ref": "../schema/base_config.schema.json" }],

--- a/ExampleExtractor/full_config.schema.json
+++ b/ExampleExtractor/full_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/ExampleExtractor/full_config.schema.json",
+    "$id": "full_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "allOf": [{ "$ref": "../schema/base_config.schema.json" }],

--- a/ExampleExtractor/full_config.schema.json
+++ b/ExampleExtractor/full_config.schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "/dotnet/ExampleExtractor/full_config.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "allOf": [{ "$ref": "../schema/base_config.schema.json" }],
     "properties": {

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -1,0 +1,27 @@
+{
+    "$id": "/dotnet/base_config.schema.json",
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "type": {
+            "type": "string",
+            "enum": ["local", "remote"]
+        },
+        "logger": {
+            "$ref": "logger_config.schema.json"
+        },
+        "metrics": {
+            "$ref": "metrics_config.schema.json"
+        },
+        "cognite": {
+            "$ref": "cognite_config.schema.json"
+        },
+        "state-store": {
+            "$ref": "state_store_config.schema.json"
+        }
+    },
+    "required": ["version"]
+}

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/base_config.schema.json",
+    "$id": "/schema/base_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -4,11 +4,14 @@
     "properties": {
         "version": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Version of the config file, the extractor specifies which config file versions are accepted in each version of the extractor."
         },
         "type": {
             "type": "string",
-            "enum": ["local", "remote"]
+            "enum": ["local", "remote"],
+            "default": "local",
+            "description": "Configuration file type. Either `local`, meaning the full config is loaded from this file, or `remote`, which means that only the `cognite` section is loaded from this file, and the rest is loaded from extraction pipelines."
         },
         "logger": {
             "$ref": "logger_config.schema.json"
@@ -23,5 +26,6 @@
             "$ref": "state_store_config.schema.json"
         }
     },
-    "required": ["version"]
+    "required": ["version"],
+    "unevaluatedProperties": false
 }

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/schema/base_config.schema.json",
+    "$id": "base_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "/dotnet/base_config.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "version": {

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "/dotnet/cognite_config.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configure connection to Cognite Data Fusion (CDF)",
     "properties": {

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/cognite_config.schema.json",
+    "$id": "/schema/cognite_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configure connection to Cognite Data Fusion (CDF)",

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/schema/cognite_config.schema.json",
+    "$id": "cognite_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configure connection to Cognite Data Fusion (CDF)",

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -1,0 +1,219 @@
+{
+    "$id": "/dotnet/metrics_config.schema.json",
+    "type": "object",
+    "properties": {
+        "project": {
+            "type": "string"
+        },
+        "api-key": {
+            "type": "string"
+        },
+        "idp-authentication": {
+            "type": "object",
+            "properties": {
+                "implementation": {
+                    "type": "string",
+                    "enum": ["MSAL", "Basic"],
+                    "default": "MSAL"
+                },
+                "authority": {
+                    "type": "string",
+                    "default": "https://login.microsoftonline.com/"
+                },
+                "client-id": {
+                    "type": "string"
+                },
+                "tenant": {
+                    "type": "string"
+                },
+                "token-url": {
+                    "type": "string"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "resource": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "audience": {
+                    "type": "string"
+                },
+                "min-ttl": {
+                    "type": "integer",
+                    "default": 30
+                }
+            }
+        },
+        "host": {
+            "type": "string",
+            "default": "https://api.cognitedata.com"
+        },
+        "cdf-retries": {
+            "type": "object",
+            "properties": {
+                "timeout": {
+                    "type": "integer",
+                    "default": 80000
+                },
+                "max-retries": {
+                    "type": "integer",
+                    "default": 5
+                },
+                "max-delay": {
+                    "type": "integer",
+                    "default": 5000
+                }
+            }
+        },
+        "cdf-chunking": {
+            "type": "object",
+            "properties": {
+                "time-series": {
+                    "type": "integer",
+                    "default": 1000
+                },
+                "assets": {
+                    "type": "integer",
+                    "default": 1000
+                },
+                "data-point-time-series": {
+                    "type": "integer",
+                    "default": 10000
+                },
+                "data-point-delete": {
+                    "type": "integer",
+                    "default": 10000
+                },
+                "data-point-list": {
+                    "type": "integer",
+                    "default": 100
+                },
+                "data-points": {
+                    "type": "integer",
+                    "default": 100000
+                },
+                "data-points-gzip-limit": {
+                    "type": "integer",
+                    "default": 5000
+                },
+                "raw-rows": {
+                    "type": "integer",
+                    "default": 10000
+                },
+                "raw-rows-delete": {
+                    "type": "integer",
+                    "default": 1000
+                },
+                "data-point-latest": {
+                    "type": "integer",
+                    "default": 100
+                },
+                "events": {
+                    "type": "integer",
+                    "default": 1000
+                },
+                "sequences": {
+                    "type": "integer",
+                    "default": 1000
+                },
+                "sequence-row-sequences": {
+                    "type": "integer",
+                    "default": 1000
+                },
+                "sequence-rows": {
+                    "type": "integer",
+                    "default": 10000
+                }
+            }
+        },
+        "cdf-throttling": {
+            "type": "object",
+            "properties": {
+                "time-series": {
+                    "type": "integer",
+                    "default": 20
+                },
+                "assets": {
+                    "type": "integer",
+                    "default": 20
+                },
+                "data-points": {
+                    "type": "integer",
+                    "default": 10
+                },
+                "raw": {
+                    "type": "integer",
+                    "default": 10
+                },
+                "ranges": {
+                    "type": "integer",
+                    "default": 20
+                },
+                "events": {
+                    "type": "integer",
+                    "default": 20
+                },
+                "sequences": {
+                    "type": "integer",
+                    "default": 20
+                }
+            }
+        },
+        "sdk-logging": {
+            "type": "object",
+            "properties": {
+                "disable": {
+                    "type": "boolean"
+                },
+                "level": {
+                    "type": "string",
+                    "enum": ["trace", "debug", "information", "warning", "error", "critical", "none"],
+                    "default": "debug"
+                },
+                "format": {
+                    "type": "string",
+                    "default": "CDF ({Message}): {HttpMethod} {Url} - {Elapsed} ms"
+                }
+            }
+        },
+        "nan-replacement": {
+            "type": ["number", "null"]
+        },
+        "extraction-pipeline": {
+            "type": "object",
+            "properties": {
+                "pipeline-id": {
+                    "type": "string",
+                    "deprecated": true
+                },
+                "external-id": {
+                    "type": "string"
+                },
+                "frequency": {
+                    "type": "integer",
+                    "default": 600
+                }
+            }
+        },
+        "certificates": {
+            "type": "object",
+            "properties": {
+                "accept-all": {
+                    "type": "boolean"
+                },
+                "allow-list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -1,219 +1,286 @@
 {
-    "$id": "/dotnet/metrics_config.schema.json",
+    "$id": "/dotnet/cognite_config.schema.json",
     "type": "object",
+    "description": "Configure connection to Cognite Data Fusion (CDF)",
     "properties": {
         "project": {
-            "type": "string"
+            "type": "string",
+            "description": "CDF project to connect to"
         },
         "api-key": {
-            "type": "string"
+            "type": "string",
+            "description": "CDF API Key, deprecated in favor of token-based authentication"
         },
         "idp-authentication": {
             "type": "object",
+            "description": "Configure authentication using OIDC tokens",
             "properties": {
                 "implementation": {
                     "type": "string",
                     "enum": ["MSAL", "Basic"],
-                    "default": "MSAL"
+                    "default": "MSAL",
+                    "description": "Implementation. Either using the MSAL library, or a custom authenticator. This is deprecated, and no longer does anything.",
+                    "deprecated": true
                 },
                 "authority": {
                     "type": "string",
-                    "default": "https://login.microsoftonline.com/"
+                    "default": "https://login.microsoftonline.com/",
+                    "description": "Authority using together with `tenant` to authenticate against azure tenants."
                 },
                 "client-id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Service principal client id."
                 },
                 "tenant": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Azure tenant"
                 },
                 "token-url": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "URL used to obtain tokens given client credentials."
                 },
                 "secret": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Service principal client secret"
                 },
                 "resource": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resource parameter passed along with request"
                 },
                 "scopes": {
                     "type": "array",
+                    "description": "A list of scopes requested for the token",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "A scope requested for the token"
                     }
                 },
                 "audience": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Audience parameter passed along with request"
                 },
                 "min-ttl": {
                     "type": "integer",
-                    "default": 30
+                    "default": 30,
+                    "description": "Requested minimum time-to-live in seconds for the token"
                 }
-            }
+            },
+            "oneOf": [{ "required": ["tenant"] }, { "required": ["token-url"] }],
+            "unevaluatedProperties": false,
+            "required": ["client-id", "secret"]
         },
         "host": {
             "type": "string",
-            "default": "https://api.cognitedata.com"
+            "default": "https://api.cognitedata.com",
+            "description": "Cognite service URL."
         },
         "cdf-retries": {
             "type": "object",
+            "description": "Configure automatic retries on requests to CDF.",
             "properties": {
                 "timeout": {
                     "type": "integer",
-                    "default": 80000
+                    "default": 80000,
+                    "description": "Timeout in milliseconds for each individual try"
                 },
                 "max-retries": {
                     "type": "integer",
-                    "default": 5
+                    "default": 5,
+                    "description": "Maximum number of retries, less than 0 retries forever"
                 },
                 "max-delay": {
                     "type": "integer",
-                    "default": 5000
+                    "default": 5000,
+                    "description": "Max delay in milliseconds between each try. Base delay is calculated according to 125*2^retry milliseconds. If less than 0, there is no maximum."
                 }
-            }
+            },
+            "unevaluatedProperties": false
         },
         "cdf-chunking": {
             "type": "object",
+            "description": "Configure chunking of data on requests to CDF. Note that increasing these may cause requests to fail due to limits in the API itself",
             "properties": {
                 "time-series": {
                     "type": "integer",
-                    "default": 1000
+                    "default": 1000,
+                    "description": "Maximum number of timeseries per get/create timeseries request"
                 },
                 "assets": {
                     "type": "integer",
-                    "default": 1000
+                    "default": 1000,
+                    "description": "Maximum number of assets per get/create assets request"
                 },
                 "data-point-time-series": {
                     "type": "integer",
-                    "default": 10000
+                    "default": 10000,
+                    "description": "Maximum number of timeseries per datapoint create request"
                 },
                 "data-point-delete": {
                     "type": "integer",
-                    "default": 10000
+                    "default": 10000,
+                    "description": "Maximum number of ranges per delete datapoints request"
                 },
                 "data-point-list": {
                     "type": "integer",
-                    "default": 100
+                    "default": 100,
+                    "description": "Maximum number of timeseries per datapoint read request. Used when getting the first point in a timeseries."
                 },
                 "data-points": {
                     "type": "integer",
-                    "default": 100000
+                    "default": 100000,
+                    "description": "Maximum number of datapoints per datapoints create request"
                 },
                 "data-points-gzip-limit": {
                     "type": "integer",
-                    "default": 5000
+                    "default": 5000,
+                    "description": "Minimum number of datapoints in request to switch to using gzip. Set to -1 to disable, and 0 to always enable (not recommended). The minimum HTTP packet size is generally 1500 bytes, so this should never be set below 100 for numeric datapoints. Even for larger packages gzip is efficient enough that packages are compressed below 1500 bytes. At 5000 it is always a performance gain. It can be set lower if bandwidth is a major issue"
                 },
                 "raw-rows": {
                     "type": "integer",
-                    "default": 10000
+                    "default": 10000,
+                    "description": "Maximum number of rows per request to cdf raw"
                 },
                 "raw-rows-delete": {
                     "type": "integer",
-                    "default": 1000
+                    "default": 1000,
+                    "description": "Maximum number of row keys per delete request to raw"
                 },
                 "data-point-latest": {
                     "type": "integer",
-                    "default": 100
+                    "default": 100,
+                    "description": "Maximum number of timeseries per datapoint read latest request"
                 },
                 "events": {
                     "type": "integer",
-                    "default": 1000
+                    "default": 1000,
+                    "description": "Maximum number of events per get/create events request"
                 },
                 "sequences": {
                     "type": "integer",
-                    "default": 1000
+                    "default": 1000,
+                    "description": "Maximum number of sequences per get/create sequences request"
                 },
                 "sequence-row-sequences": {
                     "type": "integer",
-                    "default": 1000
+                    "default": 1000,
+                    "description": "Maximum number of sequences per create sequence rows request"
                 },
                 "sequence-rows": {
                     "type": "integer",
-                    "default": 10000
+                    "default": 10000,
+                    "description": "Maximum number of sequence rows per sequence when creating rows"
                 }
-            }
+            },
+            "unevaluatedProperties": false
         },
         "cdf-throttling": {
             "type": "object",
+            "description": "Configure how requests to CDF should be throttled",
             "properties": {
                 "time-series": {
                     "type": "integer",
-                    "default": 20
+                    "default": 20,
+                    "description": "Maximum number of parallel requests per timeseries operation"
                 },
                 "assets": {
                     "type": "integer",
-                    "default": 20
+                    "default": 20,
+                    "description": "Maximum number of parallel requests per assets operation"
                 },
                 "data-points": {
                     "type": "integer",
-                    "default": 10
+                    "default": 10,
+                    "description": "Maximum number of parallel requests per datapoints operation"
                 },
                 "raw": {
                     "type": "integer",
-                    "default": 10
+                    "default": 10,
+                    "description": "Maximum number of parallel requests per raw operation"
                 },
                 "ranges": {
                     "type": "integer",
-                    "default": 20
+                    "default": 20,
+                    "description": "Maximum number of parallel requests per get first/last datapoint operation"
                 },
                 "events": {
                     "type": "integer",
-                    "default": 20
+                    "default": 20,
+                    "description": "Maximum number of parallel requests per events operation"
                 },
                 "sequences": {
                     "type": "integer",
-                    "default": 20
+                    "default": 20,
+                    "description": "Maximum number of parallel requests per sequences operation"
                 }
-            }
+            },
+            "unevaluatedProperties": false
         },
         "sdk-logging": {
             "type": "object",
+            "description": "Configure logging of requests from the SDK",
             "properties": {
                 "disable": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "True to disable logging from the SDK, it is enabled by default"
                 },
                 "level": {
                     "type": "string",
                     "enum": ["trace", "debug", "information", "warning", "error", "critical", "none"],
-                    "default": "debug"
+                    "default": "debug",
+                    "description": "Log level to log messages from the SDK at"
                 },
                 "format": {
                     "type": "string",
-                    "default": "CDF ({Message}): {HttpMethod} {Url} - {Elapsed} ms"
+                    "default": "CDF ({Message}): {HttpMethod} {Url} - {Elapsed} ms",
+                    "description": "Format of the log message"
                 }
-            }
+            },
+            "unevaluatedProperties": false
         },
         "nan-replacement": {
-            "type": ["number", "null"]
+            "type": ["number", "null"],
+            "description": "Replacement for NaN values when writing to CDF."
         },
         "extraction-pipeline": {
             "type": "object",
+            "description": "Configure an associated extraction pipeline",
             "properties": {
                 "pipeline-id": {
                     "type": "string",
-                    "deprecated": true
+                    "deprecated": true,
+                    "description": "ExternalId of the extraction pipeline, deprecated in favor of ExternalId"
                 },
                 "external-id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "ExternalId of the extraction pipeline"
                 },
                 "frequency": {
                     "type": "integer",
-                    "default": 600
+                    "default": 600,
+                    "description": "Frequency to report `Seen` to the extraction pipeline in seconds. Less than or equal to zero will not report automatically"
                 }
-            }
+            },
+            "unevaluatedProperties": false
         },
         "certificates": {
             "type": "object",
+            "description": "Configure special handling of SSL certificates. This should never be considered a permanent solution to certificate problems",
             "properties": {
                 "accept-all": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Accept all remote SSL certificates. This introduces a severe risk of man-in-the-middle attacks"
                 },
                 "allow-list": {
                     "type": "array",
+                    "description": "List of certificate thumbprints to automatically accept. This is a much smaller risk than accepting all certificates",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "A certificate thumbprint to automatically accept, even if it is invalid or lacking a valid root certificate"
                     }
                 }
-            }
+            },
+            "unevaluatedProperties": false
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/schema/high_availability.schema.json
+++ b/schema/high_availability.schema.json
@@ -1,0 +1,38 @@
+{
+    "$id": "/dotnet/high_availability.schema.json",
+    "type": "object",
+    "properties": {
+        "index": {
+            "type": "integer"
+        },
+        "raw": {
+            "type": "object",
+            "properties": {
+                "database-name": {
+                    "type": "string"
+                },
+                "table-name": {
+                    "type": "string"
+                }
+            },
+            "required": ["database-name", "table-name"]
+        },
+        "redis": {
+            "type": "object",
+            "properties": {
+                "connection-string": {
+                    "type": "string"
+                },
+                "table-name": {
+                    "type": "string"
+                }
+            },
+            "required": ["connection-string", "table-name"]
+        }
+    },
+    "oneOf": [
+        { "required": ["raw"] },
+        { "required": ["redis"] }
+    ],
+    "required": ["index"]
+}

--- a/schema/high_availability.schema.json
+++ b/schema/high_availability.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/schema/high_availability.schema.json",
+    "$id": "high_availability.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration to allow you to run multiple redundant extractors. Each extractor needs a unique index.",

--- a/schema/high_availability.schema.json
+++ b/schema/high_availability.schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "/dotnet/high_availability.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration to allow you to run multiple redundant extractors. Each extractor needs a unique index.",
     "properties": {

--- a/schema/high_availability.schema.json
+++ b/schema/high_availability.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/high_availability.schema.json",
+    "$id": "/schema/high_availability.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration to allow you to run multiple redundant extractors. Each extractor needs a unique index.",

--- a/schema/high_availability.schema.json
+++ b/schema/high_availability.schema.json
@@ -1,38 +1,50 @@
 {
     "$id": "/dotnet/high_availability.schema.json",
     "type": "object",
+    "description": "Configuration to allow you to run multiple redundant extractors. Each extractor needs a unique index.",
     "properties": {
         "index": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Unique index of this extractor. Each redundant extractor must have a unique index",
+            "minimum": 0
         },
         "raw": {
             "type": "object",
+            "description": "Configuration to use Raw as backend for high availability",
             "properties": {
                 "database-name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Raw database to store high availability states in"
                 },
                 "table-name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Raw table to store high availability states in"
                 }
             },
-            "required": ["database-name", "table-name"]
+            "required": ["database-name", "table-name"],
+            "unevaluatedProperties": false
         },
         "redis": {
             "type": "object",
+            "description": "Configuration to use a Redis store as backend for high availability",
             "properties": {
                 "connection-string": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Connection string to connect to redis instance"
                 },
                 "table-name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Redis table name to store high availability states in"
                 }
             },
-            "required": ["connection-string", "table-name"]
+            "required": ["connection-string", "table-name"],
+            "unevaluatedProperties": false
         }
     },
     "oneOf": [
         { "required": ["raw"] },
         { "required": ["redis"] }
     ],
-    "required": ["index"]
+    "required": ["index"],
+    "unevaluatedProperties": false
 }

--- a/schema/logger_config.schema.json
+++ b/schema/logger_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/logger_config.schema.json",
+    "$id": "/schema/logger_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for logging to console or file.",

--- a/schema/logger_config.schema.json
+++ b/schema/logger_config.schema.json
@@ -1,0 +1,51 @@
+{
+    "$id": "/dotnet/logger_config.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "console": {
+            "type": "object",
+            "properties": {
+                "console": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "string",
+                            "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
+                        },
+                        "stderr-level": {
+                            "type": "string",
+                            "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
+                        }
+                    }
+                }
+            }
+        },
+        "file": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
+                },
+                "path": {
+                    "type": "string"
+                },
+                "retention-limit": {
+                    "type": "integer",
+                    "min": 1
+                },
+                "rolling-interval": {
+                    "type": "string",
+                    "enum": ["day", "hour"]
+                }
+            }
+        },
+        "trace-listener": {
+            "level": {
+                "type": "string",
+                "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
+            }
+        }
+    }
+}

--- a/schema/logger_config.schema.json
+++ b/schema/logger_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/schema/logger_config.schema.json",
+    "$id": "logger_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for logging to console or file.",

--- a/schema/logger_config.schema.json
+++ b/schema/logger_config.schema.json
@@ -2,50 +2,68 @@
     "$id": "/dotnet/logger_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
+    "description": "Configuration for logging to console or file.",
     "properties": {
         "console": {
             "type": "object",
-            "properties": {
-                "console": {
-                    "type": "object",
-                    "properties": {
-                        "level": {
-                            "type": "string",
-                            "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
-                        },
-                        "stderr-level": {
-                            "type": "string",
-                            "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
-                        }
-                    }
-                }
-            }
-        },
-        "file": {
-            "type": "object",
+            "description": "Configuration for logging to the console.",
             "properties": {
                 "level": {
                     "type": "string",
+                    "description": "Minimum level of log events to write to the console.",
+                    "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
+                },
+                "stderr-level": {
+                    "type": "string",
+                    "description": "Log events at this level or above are redirected to standard error.",
+                    "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
+                }
+            },
+            "required": ["level"],
+            "unevaluatedProperties": false
+        },
+        "file": {
+            "type": "object",
+            "description": "Configuration for logging to a rotating log file.",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "description": "Minimum level of log events to write to file.",
                     "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
                 },
                 "path": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Path to the files to be logged. If this is set to `logs/log.txt`, logs on the form `logs/log[date].txt` will be created, depending on `rolling-interval`."
                 },
                 "retention-limit": {
                     "type": "integer",
-                    "min": 1
+                    "min": 1,
+                    "description": "Maximum number of log files that are kept in the log folder",
+                    "default": 31
                 },
                 "rolling-interval": {
                     "type": "string",
-                    "enum": ["day", "hour"]
+                    "enum": ["day", "hour"],
+                    "description": "Rolling interval for log files. Either `day` or `hour`",
+                    "default": "day"
                 }
-            }
+            },
+            "required": ["level", "path"],
+            "unevaluatedProperties": false
         },
         "trace-listener": {
-            "level": {
-                "type": "string",
-                "enum": ["verbose", "debug", "information", "warning", "error", "fatal"]
-            }
+            "type": "object",
+            "description": "Adds a listener that uses the configured logger to output messages from `System.Diagnostics.Trace`",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": ["verbose", "debug", "information", "warning", "error", "fatal"],
+                    "description": "Level to output trace messages at"
+                }
+            },
+            "required": ["level"],
+            "unevaluatedProperties": false
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -1,0 +1,41 @@
+{
+    "$id": "/dotnet/metrics_config.schema.json",
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "push-gateways": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "host": {
+                        "type": "string"
+                    },
+                    "job": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    },
+                    "push-interval": {
+                        "type": "integer",
+                        "default": 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/schema/metrics_config.schema.json",
+    "$id": "metrics_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for prometheus metrics destinations.",

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "/dotnet/metrics_config.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for prometheus metrics destinations.",
     "properties": {

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -1,41 +1,59 @@
 {
     "$id": "/dotnet/metrics_config.schema.json",
     "type": "object",
+    "description": "Configuration for prometheus metrics destinations.",
     "properties": {
         "server": {
             "type": "object",
+            "description": "Configuration for a prometheus scrape server.",
             "properties": {
                 "host": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Host name for the server.",
+                    "examples": ["localhost"]
                 },
                 "port": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Port to host the prometheus scrape server on"
                 }
-            }
+            },
+            "required": ["host", "port"],
+            "unevaluatedProperties": false
         },
         "push-gateways": {
             "type": "array",
+            "uniqueItems": true,
+            "description": "A list of push gateway destinations to push metrics to",
             "items": {
                 "type": "object",
                 "properties": {
                     "host": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "URI of the pushgateway host",
+                        "examples": ["http://localhost:9091"]
                     },
                     "job": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Name of the job"
                     },
                     "username": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Username for basic authentication"
                     },
                     "password": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Password for basic authentication"
                     },
                     "push-interval": {
                         "type": "integer",
-                        "default": 1
+                        "default": 1,
+                        "description": "Interval in seconds between each push to the gateway"
                     }
-                }
+                },
+                "required": ["host", "job"],
+                "unevaluatedProperties": false
             }
         }
-    }
+    },
+    "unevaluatedProperties": false
 }

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/metrics_config.schema.json",
+    "$id": "/schema/metrics_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Configuration for prometheus metrics destinations.",

--- a/schema/state_store_config.schema.json
+++ b/schema/state_store_config.schema.json
@@ -1,5 +1,6 @@
 {
     "$id": "/dotnet/state_store_config.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Store state in a local database or in CDF raw to start the extractor more efficiently",
     "properties": {

--- a/schema/state_store_config.schema.json
+++ b/schema/state_store_config.schema.json
@@ -1,14 +1,19 @@
 {
     "$id": "/dotnet/state_store_config.schema.json",
     "type": "object",
+    "description": "Store state in a local database or in CDF raw to start the extractor more efficiently",
     "properties": {
         "location": {
-            "type": "string"
+            "type": "string",
+            "description": "Path to .db file, or name of raw database containing buffer."
         },
         "database": {
             "type": "string",
             "enum": ["None", "LiteDb", "Raw"],
-            "default": "None"
+            "default": "None",
+            "description": "Which type of database to use."
         }
-    }
+    },
+    "required": ["location"],
+    "unevaluatedProperties": false
 }

--- a/schema/state_store_config.schema.json
+++ b/schema/state_store_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/dotnet/state_store_config.schema.json",
+    "$id": "/schema/state_store_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Store state in a local database or in CDF raw to start the extractor more efficiently",

--- a/schema/state_store_config.schema.json
+++ b/schema/state_store_config.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "/schema/state_store_config.schema.json",
+    "$id": "state_store_config.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "description": "Store state in a local database or in CDF raw to start the extractor more efficiently",

--- a/schema/state_store_config.schema.json
+++ b/schema/state_store_config.schema.json
@@ -1,0 +1,14 @@
+{
+    "$id": "/dotnet/state_store_config.schema.json",
+    "type": "object",
+    "properties": {
+        "location": {
+            "type": "string"
+        },
+        "database": {
+            "type": "string",
+            "enum": ["None", "LiteDb", "Raw"],
+            "default": "None"
+        }
+    }
+}


### PR DESCRIPTION
Author schema definitions for extractor utils.

We should look into a way to host these publicly, so that we can retrieve them as part of CICD.

To make writing these bearable, we must be able to split them into separate files. When storing them in the database we probably would like to download and merge them. A solution could be to use the `$defs` keyword:

 - Scan the document for `$ref`s
 - Load all referenced documents, either from the internet or from local files.
 - Store each referenced item in `$defs`.
 - Replace remote refs with local refs in generated document.

This is doable, and relatively clean.

The schema can be referenced quite elegantly from github, so long as we tag releases:

`https://github.com/cognitedata/dotnet-extractor-utils/blob/v1.4.0/README.md?raw=true` is a public, plaintext reference to the readme file at version 1.4.0.