### PR TITLE
Remove top level unevaluatedProperties

### DIFF
--- a/ExampleExtractor/config.yml
+++ b/ExampleExtractor/config.yml
@@ -19,6 +19,7 @@ high-availability:
   raw:
     database-name: ${BF_TEST_DB}
     table-name: ${BF_TEST_TABLE}
+  foo: bar
 logger:
   console:
     level: debug

--- a/ExampleExtractor/full_config.schema.json
+++ b/ExampleExtractor/full_config.schema.json
@@ -3,9 +3,11 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "allOf": [{ "$ref": "../schema/base_config.schema.json" }],
+    "unevaluatedProperties": false,
     "properties": {
         "high-availability": {
-            "$ref": "../schema/high_availability.schema.json"
+            "$ref": "../schema/high_availability.schema.json",
+            "unevaluatedProperties": false
         }
     }
 }

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -15,16 +15,20 @@
             "description": "Configuration file type. Either `local`, meaning the full config is loaded from this file, or `remote`, which means that only the `cognite` section is loaded from this file, and the rest is loaded from extraction pipelines."
         },
         "logger": {
-            "$ref": "logger_config.schema.json"
+            "$ref": "logger_config.schema.json",
+            "unevaluatedProperties": false
         },
         "metrics": {
-            "$ref": "metrics_config.schema.json"
+            "$ref": "metrics_config.schema.json",
+            "unevaluatedProperties": false
         },
         "cognite": {
-            "$ref": "cognite_config.schema.json"
+            "$ref": "cognite_config.schema.json",
+            "unevaluatedProperties": false
         },
         "state-store": {
-            "$ref": "state_store_config.schema.json"
+            "$ref": "state_store_config.schema.json",
+            "unevaluatedProperties": false
         }
     },
     "required": ["version"]

--- a/schema/base_config.schema.json
+++ b/schema/base_config.schema.json
@@ -27,6 +27,5 @@
             "$ref": "state_store_config.schema.json"
         }
     },
-    "required": ["version"],
-    "unevaluatedProperties": false
+    "required": ["version"]
 }

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -282,6 +282,5 @@
             },
             "unevaluatedProperties": false
         }
-    },
-    "unevaluatedProperties": false
+    }
 }

--- a/schema/high_availability.schema.json
+++ b/schema/high_availability.schema.json
@@ -46,6 +46,5 @@
         { "required": ["raw"] },
         { "required": ["redis"] }
     ],
-    "required": ["index"],
-    "unevaluatedProperties": false
+    "required": ["index"]
 }

--- a/schema/logger_config.schema.json
+++ b/schema/logger_config.schema.json
@@ -64,6 +64,5 @@
             "required": ["level"],
             "unevaluatedProperties": false
         }
-    },
-    "unevaluatedProperties": false
+    }
 }

--- a/schema/metrics_config.schema.json
+++ b/schema/metrics_config.schema.json
@@ -55,6 +55,5 @@
                 "unevaluatedProperties": false
             }
         }
-    },
-    "unevaluatedProperties": false
+    }
 }

--- a/schema/state_store_config.schema.json
+++ b/schema/state_store_config.schema.json
@@ -15,6 +15,5 @@
             "description": "Which type of database to use."
         }
     },
-    "required": ["location"],
-    "unevaluatedProperties": false
+    "required": ["location"]
 }


### PR DESCRIPTION
They make it so that we're unable to extend them (which makes sense). Any types which we intend users to extend we drop unevaluatedProperties from. This still works because we just let users add those directly on their own properties if they use them directly.

See ExampleExtractor/full_config.schema.json for an example, we put unevaluatedProperties on the top level, and inside each externally referenced property, indicating that we won't extend them further.

In theory you could reference properties from other types directly, and extending those would work poorly, but that's a sacrifice we can make.