### PR TITLE
Add support for parsing null values from YAML

### DIFF
--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -1,5 +1,3 @@
-using Cognite.Extractor.Common;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Cognite.Extractor.Common;
+using Microsoft.Extensions.DependencyInjection;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
@@ -192,20 +192,23 @@ namespace Cognite.Extractor.Configuration
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1508: Avoid dead conditional code", Justification = "Other methods using this can still pass null as parameter")]
-        private static void CheckVersion(int version, params int[]? acceptedConfigVersions) {
+        private static void CheckVersion(int version, params int[]? acceptedConfigVersions)
+        {
             if (acceptedConfigVersions == null || acceptedConfigVersions.Length == 0)
             {
                 return;
             }
             var accept = new List<int>(acceptedConfigVersions);
-            if (!accept.Contains(version)) {
+            if (!accept.Contains(version))
+            {
                 throw new ConfigurationException($"Config version {version} is not supported by this extractor");
             }
         }
 
         private static int GetVersion(Dictionary<object, object> versionedConfig)
         {
-            if (versionedConfig.TryGetValue("version", out dynamic version)) {
+            if (versionedConfig.TryGetValue("version", out dynamic version))
+            {
                 if (int.TryParse(version, out int intVersion))
                 {
                     return intVersion;
@@ -316,6 +319,8 @@ namespace Cognite.Extractor.Configuration
         {
         }
 
+        private static HashSet<string> _nullLiteralValues { get; set; } = new HashSet<string>() { "null", "NULL", "Null", "", "~" };
+
         private static bool IsNumericType(Type t)
         {
             var tc = Type.GetTypeCode(t);
@@ -337,7 +342,15 @@ namespace Cognite.Extractor.Configuration
                 return false;
             }
 
-            value = Regex.Replace(scalar.Value, @"\$\{([A-Za-z0-9_]+)\}", LookupEnvironment);
+            if (_nullLiteralValues.Contains(scalar.Value))
+            {
+                value = null;
+            }
+            else
+            {
+                value = Regex.Replace(scalar.Value, @"\$\{([A-Za-z0-9_]+)\}", LookupEnvironment);
+            }
+
             return true;
         }
 


### PR DESCRIPTION
This PR updates YAML deserializer to support null value parsing. Possible null representations are meant to cover the options from https://yaml.org/type/null.html. 