### PR TITLE
Fix retry counting

### DIFF
--- a/Cognite.Common/Retry.cs
+++ b/Cognite.Common/Retry.cs
@@ -95,11 +95,11 @@ namespace Cognite.Extractor.Common
             {
                 if (config.MaxTries > 0)
                 {
-                    logger.LogDebug("Run task {Task} attempt {Tries}/{Max}. Elapsed: {Time}", name, tries, config.MaxTries, DateTime.UtcNow - start);
+                    logger.LogDebug("Run task {Task} attempt {Tries}/{Max}. Elapsed: {Time}", name, tries + 1, config.MaxTries, DateTime.UtcNow - start);
                 }
                 else
                 {
-                    logger.LogDebug("Run task {Task} attempt {Tries}. Elapsed: {Time}", name, tries, DateTime.UtcNow - start);
+                    logger.LogDebug("Run task {Task} attempt {Tries}. Elapsed: {Time}", name, tries + 1, DateTime.UtcNow - start);
                 }
                 try
                 {
@@ -108,7 +108,7 @@ namespace Cognite.Extractor.Common
                 }
                 catch (Exception ex)
                 {
-                    if (shouldRetry(ex) && (tries < config.MaxTries || config.MaxTries == 0) && ((DateTime.UtcNow - start) < config.TimeoutValue.Value || config.TimeoutValue.Value == Timeout.InfiniteTimeSpan))
+                    if (shouldRetry(ex) && (tries < config.MaxTries - 1 || config.MaxTries == 0) && ((DateTime.UtcNow - start) < config.TimeoutValue.Value || config.TimeoutValue.Value == Timeout.InfiniteTimeSpan))
                     {
                         var delay = CogniteTime.Min(config.MaxDelayValue.Value, TimeSpan.FromTicks(config.InitialDelayValue.Value.Ticks * (int)Math.Pow(2, Math.Min(tries, 13))));
                         logger.LogTrace(ex, "Operation {Op} failed with error {Message}", name, ex.Message);
@@ -192,11 +192,11 @@ namespace Cognite.Extractor.Common
             {
                 if (config.MaxTries > 0)
                 {
-                    logger.LogDebug("Run task {Task} attempt {Tries}/{Max}. Elapsed: {Time}", name, tries, config.MaxTries, DateTime.UtcNow - start);
+                    logger.LogDebug("Run task {Task} attempt {Tries}/{Max}. Elapsed: {Time}", name, tries + 1, config.MaxTries, DateTime.UtcNow - start);
                 }
                 else
                 {
-                    logger.LogDebug("Run task {Task} attempt {Tries}. Elapsed: {Time}", name, tries, DateTime.UtcNow - start);
+                    logger.LogDebug("Run task {Task} attempt {Tries}. Elapsed: {Time}", name, tries + 1, DateTime.UtcNow - start);
                 }
                 try
                 {
@@ -204,7 +204,7 @@ namespace Cognite.Extractor.Common
                 }
                 catch (Exception ex)
                 {
-                    if (shouldRetry(ex) && (tries < config.MaxTries || config.MaxTries == 0) && ((DateTime.UtcNow - start) < config.TimeoutValue.Value || config.TimeoutValue.Value == Timeout.InfiniteTimeSpan))
+                    if (shouldRetry(ex) && (tries < config.MaxTries - 1 || config.MaxTries == 0) && ((DateTime.UtcNow - start) < config.TimeoutValue.Value || config.TimeoutValue.Value == Timeout.InfiniteTimeSpan))
                     {
                         var delay = CogniteTime.Min(config.MaxDelayValue.Value, TimeSpan.FromTicks(config.InitialDelayValue.Value.Ticks * (int)Math.Pow(2, Math.Min(tries, 13))));
                         logger.LogTrace(ex, "Operation {Op} failed with error {Message}", name, ex.Message);

--- a/ExtractorUtils.Test/unit/RetryTest.cs
+++ b/ExtractorUtils.Test/unit/RetryTest.cs
@@ -36,7 +36,7 @@ namespace ExtractorUtils.Test.Unit
             {
                 if (counter++ < 2) throw new Exception();
             }
-            await Assert.ThrowsAsync<Exception>(async () => await RetryUtil.RetryAsync("test", Test, new RetryUtilConfig { InitialDelay = "10ms", MaxDelay = "1s", MaxTries = 1 }, _ => true, _logger, CancellationToken.None));
+            await Assert.ThrowsAsync<Exception>(async () => await RetryUtil.RetryAsync("test", Test, new RetryUtilConfig { InitialDelay = "10ms", MaxDelay = "1s", MaxTries = 2 }, _ => true, _logger, CancellationToken.None));
         }
 
         [Fact(Timeout = 20000)]


### PR DESCRIPTION
The number of maximum retries should be equal to max-retries, and the logged attempt number should start at 1.