### PR TITLE
Reload remote config after restart

### DIFF
--- a/ExtractorUtils/ExtractorRunner.cs
+++ b/ExtractorUtils/ExtractorRunner.cs
@@ -232,6 +232,8 @@ namespace Cognite.Extractor.Utils
                 catch { }
             }
 
+            bool usesRemoteConfig = false;
+
             Console.CancelKeyPress += CancelKeyPressHandler;
             while (!source.IsCancellationRequested)
             {
@@ -245,8 +247,7 @@ namespace Cognite.Extractor.Utils
                 ConfigurationException? exception = null;
                 try
                 {
-                    bool usesRemoteConfig = false;
-                    if (options.AllowRemoteConfig && options.Config == null)
+                    if (options.AllowRemoteConfig && options.Config == null || usesRemoteConfig)
                     {
                         options.Config = await services.AddRemoteConfig<TConfig>(
                             options.StartupLogger,


### PR DESCRIPTION
The extractor would not properly enable remote config after restarting, since it kept the previous config. This meant that config changes were not picked up. This should fix that, making it so that if we enable remote config once, it is enabled in all future iterations as well.