### PR TITLE
Add config class for data sets

### DIFF
--- a/Cognite.Extensions/DataSetExtensions.cs
+++ b/Cognite.Extensions/DataSetExtensions.cs
@@ -1,0 +1,78 @@
+﻿using CogniteSdk;
+using System;
+using System.Threading.Tasks;
+using System.Threading;
+using CogniteSdk.Resources;
+using System.Linq;
+
+namespace Cognite.Extensions
+{
+    /// <summary>
+    /// Config for setting a dataset.
+    /// </summary>
+    public class DataSetConfig
+    {
+        /// <summary>
+        /// Dataset external ID.
+        /// </summary>
+        public string? ExternalId { get; set; }
+        /// <summary>
+        /// Dataset ID.
+        /// </summary>
+        public long? Id { get; set; }
+    }
+
+    /// <summary>
+    /// Extensions for cognite data sets.
+    /// </summary>
+    public static class DataSetExtensions
+    {
+        /// <summary>
+        /// Retrieve the configured data set ID. This will only make a request to CDF
+        /// if ExternalId is configured without Id.
+        /// 
+        /// Will throw an exception if configured using ExternalId and retrieval failed.
+        /// </summary>
+        /// <param name="resource">Client to use for retrieval.</param>
+        /// <param name="config">Config to retrieve data set for.</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Dataset ID if configured</returns>
+        public static async Task<long?> GetId(this DataSetsResource resource, DataSetConfig config, CancellationToken token = default)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (config.Id != null) return config.Id.Value;
+
+            var dataset = await resource.Get(config, token).ConfigureAwait(false);
+            return dataset?.Id;
+        }
+
+        /// <summary>
+        /// Retrieve the configured dataset. Will throw an exception if the dataset does not exist,
+        /// or if retrieval failed.
+        /// </summary>
+        /// <param name="resource">Client to use for retrieval.</param>
+        /// <param name="config">Config to retrieve data set for.</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Dataset if configured</returns>
+        public static async Task<DataSet?> Get(this DataSetsResource resource, DataSetConfig config, CancellationToken token = default)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (resource == null) throw new ArgumentNullException(nameof(resource));
+            Identity id;
+            if (config.Id != null)
+            {
+                id = Identity.Create(config.Id.Value);
+            }
+            else if (config.ExternalId != null)
+            {
+                id = Identity.Create(config.ExternalId);
+            }
+            else
+            {
+                return null;
+            }
+            var dss = await resource.RetrieveAsync(new[] { id }, false, token).ConfigureAwait(false);
+            return dss.FirstOrDefault();
+        }
+    }
+}

--- a/ExtractorUtils.Test/CDFTester.cs
+++ b/ExtractorUtils.Test/CDFTester.cs
@@ -55,7 +55,6 @@ namespace ExtractorUtils.Test
 
         public async Task<long> GetDataSetId()
         {
-
             var dataSets = await Destination.CogniteClient.DataSets.RetrieveAsync(new[] { "test-dataset" }, true);
             if (!dataSets.Any())
             {

--- a/ExtractorUtils.Test/integration/AuthIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/AuthIntegrationTest.cs
@@ -78,14 +78,6 @@ namespace ExtractorUtils.Test.Integration
                 {
                     await Assert.ThrowsAsync<CogniteUtilsException>(() => tester.Destination.TestCogniteConfig(tester.Source.Token));
                 }
-
-                // Not logged in
-                configKey = CDFTester.GetConfig(host);
-                configKey[6] = "  api-key: invalid-api-key";
-                using (var tester = new CDFTester(configKey, _output))
-                {
-                    await Assert.ThrowsAsync<CogniteUtilsException>(() => tester.Destination.TestCogniteConfig(tester.Source.Token));
-                }
             }
         }
 

--- a/ExtractorUtils.Test/integration/RawHighAvailabilityTest.cs
+++ b/ExtractorUtils.Test/integration/RawHighAvailabilityTest.cs
@@ -104,8 +104,8 @@ namespace ExtractorUtils.Test.Integration
         public async void TestRestartExtractor()
         {
             // Creating config for two extractors.
-            string configPath_0 = SetupConfig(index: 0);
-            string configPath_1 = SetupConfig(index: 1);
+            string configPath_0 = SetupConfig(index: 2);
+            string configPath_1 = SetupConfig(index: 3);
 
             using var source_0 = new CancellationTokenSource();
             using var source_1 = new CancellationTokenSource();

--- a/ExtractorUtils.Test/integration/UtilsIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/UtilsIntegrationTest.cs
@@ -1,9 +1,6 @@
-﻿using Cognite.Extractor.Utils;
+﻿using Cognite.Extensions;
 using CogniteSdk;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -28,36 +25,32 @@ namespace ExtractorUtils.Test.integration
             var config = new DataSetConfig();
 
             // No configured data set
-            Assert.Null(await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token));
-            Assert.Null(await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+            Assert.Null(await tester.Destination.CogniteClient.DataSets.Get(config, tester.Source.Token));
+            Assert.Null(await tester.Destination.CogniteClient.DataSets.GetId(config, tester.Source.Token));
 
             // Configured with correct ID
             config.Id = dataSetId;
-            Assert.Equal(dataSetId, (await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token)).Id);
-            Assert.Equal(dataSetId, await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+            Assert.Equal(dataSetId, (await tester.Destination.CogniteClient.DataSets.Get(config, tester.Source.Token)).Id);
+            Assert.Equal(dataSetId, await tester.Destination.CogniteClient.DataSets.GetId(config, tester.Source.Token));
 
             // Configured with correct externalId
             config.Id = null;
             config.ExternalId = dataSetExternalId;
-            Assert.Equal(dataSetId, (await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token)).Id);
-            Assert.Equal(dataSetId, await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+            Assert.Equal(dataSetId, (await tester.Destination.CogniteClient.DataSets.Get(config, tester.Source.Token)).Id);
+            Assert.Equal(dataSetId, await tester.Destination.CogniteClient.DataSets.GetId(config, tester.Source.Token));
 
             // Configured with incorrect ID
             config.Id = 123;
             config.ExternalId = null;
-            await Assert.ThrowsAsync<ResponseException>(async () => await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token));
+            await Assert.ThrowsAsync<ResponseException>(async () => await tester.Destination.CogniteClient.DataSets.Get(config, tester.Source.Token));
             // This doesn't actually test the data set, needed for backwards compatibility in some extractors.
-            Assert.Equal(123, await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+            Assert.Equal(123, await tester.Destination.CogniteClient.DataSets.GetId(config, tester.Source.Token));
 
             // Configured with incorrect external ID
             config.Id = null;
             config.ExternalId = "some-dataset-that-doesnt-exist";
-            await Assert.ThrowsAsync<ResponseException>(async () => await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token));
-            await Assert.ThrowsAsync<ResponseException>(async () => await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
-
-            // No client
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await config.GetDataSet(null, tester.Source.Token));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await config.GetDataSetId(null, tester.Source.Token));
+            await Assert.ThrowsAsync<ResponseException>(async () => await tester.Destination.CogniteClient.DataSets.Get(config, tester.Source.Token));
+            await Assert.ThrowsAsync<ResponseException>(async () => await tester.Destination.CogniteClient.DataSets.GetId(config, tester.Source.Token));
         }
     }
 }

--- a/ExtractorUtils.Test/integration/UtilsIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/UtilsIntegrationTest.cs
@@ -1,0 +1,63 @@
+﻿using Cognite.Extractor.Utils;
+using CogniteSdk;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ExtractorUtils.Test.integration
+{
+    public class UtilsIntegrationTest
+    {
+        private readonly ITestOutputHelper _output;
+        public UtilsIntegrationTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task TestGetDataSet()
+        {
+            using var tester = new CDFTester(CDFTester.GetConfig(CogniteHost.BlueField), _output);
+
+            var dataSetId = await tester.GetDataSetId();
+            var dataSetExternalId = "test-dataset";
+            var config = new DataSetConfig();
+
+            // No configured data set
+            Assert.Null(await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token));
+            Assert.Null(await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+
+            // Configured with correct ID
+            config.Id = dataSetId;
+            Assert.Equal(dataSetId, (await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token)).Id);
+            Assert.Equal(dataSetId, await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+
+            // Configured with correct externalId
+            config.Id = null;
+            config.ExternalId = dataSetExternalId;
+            Assert.Equal(dataSetId, (await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token)).Id);
+            Assert.Equal(dataSetId, await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+
+            // Configured with incorrect ID
+            config.Id = 123;
+            config.ExternalId = null;
+            await Assert.ThrowsAsync<ResponseException>(async () => await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token));
+            // This doesn't actually test the data set, needed for backwards compatibility in some extractors.
+            Assert.Equal(123, await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+
+            // Configured with incorrect external ID
+            config.Id = null;
+            config.ExternalId = "some-dataset-that-doesnt-exist";
+            await Assert.ThrowsAsync<ResponseException>(async () => await config.GetDataSet(tester.Destination.CogniteClient, tester.Source.Token));
+            await Assert.ThrowsAsync<ResponseException>(async () => await config.GetDataSetId(tester.Destination.CogniteClient, tester.Source.Token));
+
+            // No client
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await config.GetDataSet(null, tester.Source.Token));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await config.GetDataSetId(null, tester.Source.Token));
+        }
+    }
+}

--- a/ExtractorUtils.Test/unit/DatapointsTest.cs
+++ b/ExtractorUtils.Test/unit/DatapointsTest.cs
@@ -317,7 +317,7 @@ namespace ExtractorUtils.Test.Unit
                 logger.LogInformation("Upload queue disposed");
 
                 Assert.Equal(3 * 23, dpCount);
-                Assert.True(cbCount == 10 || cbCount == 11);
+                Assert.True(cbCount >= 10 && cbCount <= 14);
                 foreach (var state in states)
                 {
                     Assert.NotEqual(CogniteTime.DateTimeEpoch, state.DestinationExtractedRange.Last);

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -422,9 +422,6 @@ namespace Cognite.Extractor.Utils
         public async Task<long?> GetDataSetId(Client client, CancellationToken token)
         {
             if (Id != null) return Id.Value;
-            if (ExternalId == null) return null;
-            if (client == null) throw new ArgumentNullException(nameof(client));
-
             var dataset = await GetDataSet(client, token).ConfigureAwait(false);
             return dataset?.Id;
         }

--- a/ExtractorUtils/Configuration/BaseConfig.cs
+++ b/ExtractorUtils/Configuration/BaseConfig.cs
@@ -1,14 +1,9 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Cognite.Extensions;
 using Cognite.Extractor.Configuration;
 using Cognite.Extractor.Logging;
 using Cognite.Extractor.Metrics;
 using Cognite.Extractor.StateStorage;
-using CogniteSdk;
 using Microsoft.Extensions.Logging;
 
 namespace Cognite.Extractor.Utils
@@ -368,64 +363,5 @@ namespace Cognite.Extractor.Utils
         /// </summary>
         public string? TableName { get; set; }
     }
-
-    /// <summary>
-    /// Config for setting a dataset.
-    /// </summary>
-    public class DataSetConfig
-    {
-        /// <summary>
-        /// Dataset external ID.
-        /// </summary>
-        public string? ExternalId { get; set; }
-        /// <summary>
-        /// Dataset ID.
-        /// </summary>
-        public long? Id { get; set; }
-
-        /// <summary>
-        /// Retrieve the configured dataset. Will throw an exception if the dataset does not exist,
-        /// or if retrieval failed.
-        /// </summary>
-        /// <param name="client">Client to use for retrieval.</param>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>Dataset if configured</returns>
-        public async Task<DataSet?> GetDataSet(Client client, CancellationToken token)
-        {
-            if (client == null) throw new ArgumentNullException(nameof(client));
-            Identity id;   
-            if (Id != null)
-            {
-                id = Identity.Create(Id.Value);
-            }
-            else if (ExternalId != null)
-            {
-                id = Identity.Create(ExternalId);
-            }
-            else
-            {
-                return null;
-            }
-            var dss = await client.DataSets.RetrieveAsync(new[] { id }, false, token).ConfigureAwait(false);
-            return dss.FirstOrDefault();
-        }
-
-        /// <summary>
-        /// Retrieve the configured data set ID. This will only make a request to CDF
-        /// if ExternalId is configured without Id.
-        /// 
-        /// Will throw an exception if configured using ExternalId and retrieval failed.
-        /// </summary>
-        /// <param name="client">Client to use for retrieval.</param>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>Dataset ID if configured</returns>
-        public async Task<long?> GetDataSetId(Client client, CancellationToken token)
-        {
-            if (Id != null) return Id.Value;
-            var dataset = await GetDataSet(client, token).ConfigureAwait(false);
-            return dataset?.Id;
-        }
-    }
-
     #endregion
 }


### PR DESCRIPTION
In order to align with python utils, it's nice to have a config class with logic for fetching data set ID.