### PR TITLE
Update allowed ranges for unix timestamps

### DIFF
--- a/Cognite.Common/CogniteTime.cs
+++ b/Cognite.Common/CogniteTime.cs
@@ -17,7 +17,9 @@ namespace Cognite.Extractor.Common
         
         private static readonly long epochTicks = DateTimeEpoch.Ticks;
         private static readonly long maxTsValue = DateTime.MaxValue.ToUnixTimeMilliseconds();
+        private static readonly long minTsValue = DateTime.MinValue.ToUnixTimeMilliseconds();
         private static readonly long maxTicksValue = DateTime.MaxValue.TicksSinceEpoch();
+        private static readonly long minTicksValue = DateTime.MinValue.TicksSinceEpoch();
 
         /// <summary>
         /// Creates an UTC DateTime object at <paramref name="msSinceEpoch"/> milliseconds after the Unix Epoch, midnight 1/1/1970.
@@ -26,9 +28,9 @@ namespace Cognite.Extractor.Common
         /// <returns>UTC DateTime object at <paramref name="msSinceEpoch"/> milliseconds after midnight 1/1/1970</returns>
         public static DateTime FromUnixTimeMilliseconds(long msSinceEpoch)
         {
-            if (msSinceEpoch < 0 || msSinceEpoch > maxTsValue)
+            if (msSinceEpoch < minTsValue || msSinceEpoch > maxTsValue)
             {
-                throw new ArgumentOutOfRangeException(nameof(msSinceEpoch), $"Timestamp value should be between {0} and {maxTsValue} ms");
+                throw new ArgumentOutOfRangeException(nameof(msSinceEpoch), $"Timestamp value should be between {minTsValue} and {maxTsValue} ms");
             }
             return DateTimeEpoch.AddMilliseconds(msSinceEpoch);
         }
@@ -40,9 +42,9 @@ namespace Cognite.Extractor.Common
         /// <returns>UTC DateTime object at <paramref name="ticksSinceEpoch"/> ticks after epoch</returns>
         public static DateTime FromTicks(long ticksSinceEpoch)
         {
-            if (ticksSinceEpoch < 0 || ticksSinceEpoch > maxTicksValue)
+            if (ticksSinceEpoch < minTicksValue || ticksSinceEpoch > maxTicksValue)
             {
-                throw new ArgumentOutOfRangeException(nameof(ticksSinceEpoch), $"Timestamp value should be between {0} and {maxTsValue} ticks");
+                throw new ArgumentOutOfRangeException(nameof(ticksSinceEpoch), $"Timestamp value should be between {minTicksValue} and {maxTicksValue} ticks");
             }
             return DateTimeEpoch.AddTicks(ticksSinceEpoch);
         }
@@ -64,15 +66,13 @@ namespace Cognite.Extractor.Common
         /// <summary>
         /// Returns the how many ticks have passed since the Unix Epoch, 1/1/1970 to the
         /// date passed as parameter. A Tick corresponds to 10 000 ms (ref. TimeSpan.TicksPerMillisecond).
+        /// 
+        /// This method may return a negative number.
         /// </summary>
         /// <param name="time">UTC DateTime object to convert</param>
         /// <returns>Number of ticks since epoch</returns>
         public static long TicksSinceEpoch(this DateTime time)
         {
-            if (time < DateTimeEpoch)
-            {
-                throw new ArgumentException($"Date {time.ToISOString()} is before Unix Epoch.");
-            }
             if (time.Kind == DateTimeKind.Local)
             {
                 throw new ArgumentException("DateTime object should be represented using UTC");

--- a/Cognite.Extensions/CogniteUtils.cs
+++ b/Cognite.Extensions/CogniteUtils.cs
@@ -38,14 +38,14 @@ namespace Cognite.Extensions
         public const int StringLengthMax = 255;
 
         /// <summary>
-        /// Cognite min timestamp (1971)
+        /// Cognite min timestamp (1900)
         /// </summary>
-        public const long TimestampMin = 31536000000L;
+        public const long TimestampMin = -2208988800000L;
 
         /// <summary>
-        /// Cognite max timestamp (2050)
+        /// Cognite max timestamp (2099)
         /// </summary>
-        public const long TimestampMax = 2556144000000L;
+        public const long TimestampMax = 4102444799999L;
 
         /// <summary>
         /// Write missing identities to the provided identity set.

--- a/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/TimeSeriesIntegrationTest.cs
@@ -677,7 +677,7 @@ namespace ExtractorUtils.Test.Integration
                         new Datapoint(DateTime.UtcNow, 1.0),
                         new Datapoint(DateTime.MaxValue, 2.0),
                         new Datapoint(DateTime.UtcNow.AddSeconds(1), double.NaN),
-                        new Datapoint(CogniteTime.DateTimeEpoch, 3.0),
+                        new Datapoint(DateTime.MinValue, 3.0),
                         new Datapoint(DateTime.UtcNow.AddSeconds(2), double.PositiveInfinity),
                         new Datapoint(DateTime.UtcNow.AddSeconds(3), double.NegativeInfinity),
                         new Datapoint(DateTime.UtcNow.AddSeconds(4), 1E101),

--- a/ExtractorUtils.Test/unit/CogniteTimeTest.cs
+++ b/ExtractorUtils.Test/unit/CogniteTimeTest.cs
@@ -59,10 +59,12 @@ namespace ExtractorUtils.Test.Unit
         {
             var d1 = CogniteTime.FromUnixTimeMilliseconds(0);
             Assert.Equal(CogniteTime.DateTimeEpoch, d1);
-
-            Assert.Throws<ArgumentOutOfRangeException>(() => CogniteTime.FromUnixTimeMilliseconds(-1));
+            Assert.Equal(CogniteTime.DateTimeEpoch.AddMilliseconds(-1), CogniteTime.FromUnixTimeMilliseconds(-1));
 
             var outOfRangeValue = DateTime.MaxValue.ToUnixTimeMilliseconds() + 1;
+            Assert.Throws<ArgumentOutOfRangeException>(() => CogniteTime.FromUnixTimeMilliseconds(outOfRangeValue));
+
+            outOfRangeValue = DateTime.MinValue.ToUnixTimeMilliseconds() - 1;
             Assert.Throws<ArgumentOutOfRangeException>(() => CogniteTime.FromUnixTimeMilliseconds(outOfRangeValue));
         }
 

--- a/ExtractorUtils.Test/unit/DatapointsTest.cs
+++ b/ExtractorUtils.Test/unit/DatapointsTest.cs
@@ -78,7 +78,7 @@ namespace ExtractorUtils.Test.Unit
                     { new Identity(1), doublePoints.Select(d => new Datapoint(DateTime.UtcNow, d))},
                     { new Identity(2), stringPoints.Select(s => new Datapoint(DateTime.UtcNow, s))},
                     { new Identity(3), new Datapoint[] { } },
-                    { new Identity(4), new Datapoint[] { new Datapoint(CogniteTime.DateTimeEpoch, 1), new Datapoint(DateTime.MaxValue, 1)}}
+                    { new Identity(4), new Datapoint[] { new Datapoint(DateTime.MinValue, 1), new Datapoint(DateTime.MaxValue, 1)}}
                 };
                 _createdDataPoints.Clear();
                 var result = await cogniteDestination.InsertDataPointsAsync(

--- a/ExtractorUtils.Test/unit/SanitationTest.cs
+++ b/ExtractorUtils.Test/unit/SanitationTest.cs
@@ -707,7 +707,7 @@ namespace ExtractorUtils.Test.Unit
                 new Datapoint(DateTime.UtcNow, 1E101),
                 new Datapoint(DateTime.UtcNow, -1E101),
                 new Datapoint(DateTime.MaxValue, 1),
-                new Datapoint(CogniteTime.DateTimeEpoch, 1)
+                new Datapoint(DateTime.MinValue, 1)
             };
 
             var result = dps.Select(dp => dp.Verify()).ToArray();
@@ -942,7 +942,7 @@ namespace ExtractorUtils.Test.Unit
             {
                 { Identity.Create("all-bad-ts"), new[] {
                     new Datapoint(DateTime.MaxValue, 1.0),
-                    new Datapoint(CogniteTime.DateTimeEpoch, 2.0)
+                    new Datapoint(DateTime.MinValue, 2.0)
                 } },
                 { Identity.Create("all-bad-value"), new[]
                 {


### PR DESCRIPTION
CDF allows negative unix timestamps now, and behavior in the utils should reflect that.