### PR TITLE
Upload queue improvements

### DIFF
--- a/Cognite.Extensions/Assets/AssetExtensions.cs
+++ b/Cognite.Extensions/Assets/AssetExtensions.cs
@@ -438,14 +438,17 @@ namespace Cognite.Extensions
                     _logger.LogDebug("Failed to update {Count} assets: {Message}",
                         toUpdate.Count(), ex.Message);
                     var error = ResultHandlers.ParseException<AssetUpdateItem>(ex, RequestType.UpdateAssets);
-                    if (error.Complete) errors.Add(error);
                     if (error.Type == ErrorType.FatalFailure
                         && (retryMode == RetryMode.OnFatal
                             || retryMode == RetryMode.OnFatalKeepDuplicates))
                     {
                         await Task.Delay(1000, token).ConfigureAwait(false);
                     }
-                    else if (retryMode == RetryMode.None) break;
+                    else if (retryMode == RetryMode.None)
+                    {
+                        errors.Add(error);
+                        break;
+                    }
                     else
                     {
                         if (!error.Complete)
@@ -461,6 +464,7 @@ namespace Cognite.Extensions
                         }
                         else
                         {
+                            errors.Add(error);
                             toUpdate = ResultHandlers.CleanFromError(error, toUpdate);
                         }
                     }

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -436,6 +436,11 @@ namespace Cognite.Extensions
         {
             return new CogniteResult<TResult, TRep>(Errors?.Select(e => e.ReplaceSkipped(replace)), Results);
         }
+
+        /// <summary>
+        /// All items that were skipped in this result. Found by joining all errors.
+        /// </summary>
+        public IEnumerable<TError> AllSkipped => Errors?.Where(e => e.Skipped != null)?.SelectMany(e => e.Skipped!) ?? Enumerable.Empty<TError>();
     }
 
     /// <summary>

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -352,6 +352,12 @@ namespace Cognite.Extensions
         {
             return new CogniteResult<TRep>(Errors?.Select(e => e.ReplaceSkipped(replace)));
         }
+
+
+        /// <summary>
+        /// All items that were skipped in this result, accross all errors.
+        /// </summary>
+        public IEnumerable<TError> AllSkipped => Errors?.Where(e => e.Skipped != null)?.SelectMany(e => e.Skipped!) ?? Enumerable.Empty<TError>();
     }
 
     /// <summary>
@@ -436,11 +442,6 @@ namespace Cognite.Extensions
         {
             return new CogniteResult<TResult, TRep>(Errors?.Select(e => e.ReplaceSkipped(replace)), Results);
         }
-
-        /// <summary>
-        /// All items that were skipped in this result. Found by joining all errors.
-        /// </summary>
-        public IEnumerable<TError> AllSkipped => Errors?.Where(e => e.Skipped != null)?.SelectMany(e => e.Skipped!) ?? Enumerable.Empty<TError>();
     }
 
     /// <summary>

--- a/Cognite.Extensions/Events/EventExtensions.cs
+++ b/Cognite.Extensions/Events/EventExtensions.cs
@@ -279,16 +279,20 @@ namespace Cognite.Extensions
                     _logger.LogDebug("Failed to create {cnt} events: {msg}",
                         toCreate.Count(), ex.Message);
                     var error = ResultHandlers.ParseException<EventCreate>(ex, RequestType.CreateEvents);
-                    errors.Add(error);
                     if (error.Type == ErrorType.FatalFailure
                         && (retryMode == RetryMode.OnFatal
                             || retryMode == RetryMode.OnFatalKeepDuplicates))
                     {
                         await Task.Delay(1000, token).ConfigureAwait(false);
                     }
-                    else if (retryMode == RetryMode.None) break;
+                    else if (retryMode == RetryMode.None)
+                    {
+                        errors.Add(error);
+                        break;
+                    }
                     else
                     {
+                        errors.Add(error);
                         toCreate = ResultHandlers.CleanFromError(error, toCreate);
                     }
                 }

--- a/Cognite.Extensions/Sequences/SequenceExtensions.cs
+++ b/Cognite.Extensions/Sequences/SequenceExtensions.cs
@@ -450,7 +450,7 @@ namespace Cognite.Extensions
                     }
                     else if (retryMode == RetryMode.None)
                     {
-                        if (error.Complete) errors.Add(error);
+                        errors.Add(error);
                         break;
                     }
                     else

--- a/Cognite.Extensions/Sequences/SequenceExtensions.cs
+++ b/Cognite.Extensions/Sequences/SequenceExtensions.cs
@@ -441,14 +441,18 @@ namespace Cognite.Extensions
                 {
                     _logger.LogDebug("Failed to create rows for {seq} sequences", toCreate.Count());
                     var error = ResultHandlers.ParseException<SequenceRowError>(ex, RequestType.CreateSequenceRows);
-                    if (error.Complete) errors.Add(error);
+
                     if (error.Type == ErrorType.FatalFailure
                         && (retryMode == RetryMode.OnFatal
                             || retryMode == RetryMode.OnFatalKeepDuplicates))
                     {
                         await Task.Delay(1000, token).ConfigureAwait(false);
                     }
-                    else if (retryMode == RetryMode.None) break;
+                    else if (retryMode == RetryMode.None)
+                    {
+                        if (error.Complete) errors.Add(error);
+                        break;
+                    }
                     else
                     {
                         if (!error.Complete)
@@ -465,6 +469,7 @@ namespace Cognite.Extensions
                         }
                         else
                         {
+                            errors.Add(error);
                             toCreate = ResultHandlers.CleanFromError(error, toCreate);
                         }
 

--- a/Cognite.Extensions/TimeSeries/TimeSeriesExtensions.cs
+++ b/Cognite.Extensions/TimeSeries/TimeSeriesExtensions.cs
@@ -324,16 +324,20 @@ namespace Cognite.Extensions
                     _logger.LogDebug("Failed to create {cnt} timeseries: {msg}",
                         toCreate.Count(), ex.Message);
                     var error = ResultHandlers.ParseException<TimeSeriesCreate>(ex, RequestType.CreateTimeSeries);
-                    errors.Add(error);
                     if (error.Type == ErrorType.FatalFailure
                         && (retryMode == RetryMode.OnFatal
                             || retryMode == RetryMode.OnFatalKeepDuplicates))
                     {
                         await Task.Delay(1000, token).ConfigureAwait(false);
                     }
-                    else if (retryMode == RetryMode.None) break;
+                    else if (retryMode == RetryMode.None)
+                    {
+                        errors.Add(error);
+                        break;
+                    }
                     else
                     {
+                        errors.Add(error);
                         toCreate = ResultHandlers.CleanFromError(error, toCreate);
                     }
                 }
@@ -428,16 +432,20 @@ namespace Cognite.Extensions
                     _logger.LogDebug("Failed to create {Count} timeseries: {Message}",
                         items.Count(), ex.Message);
                     var error = ResultHandlers.ParseException<TimeSeriesUpdateItem>(ex, RequestType.UpdateTimeSeries);
-                    errors.Add(error);
                     if (error.Type == ErrorType.FatalFailure
                         && (retryMode == RetryMode.OnFatal
                             || retryMode == RetryMode.OnFatalKeepDuplicates))
                     {
                         await Task.Delay(1000, token).ConfigureAwait(false);
                     }
-                    else if (retryMode == RetryMode.None) break;
+                    else if (retryMode == RetryMode.None)
+                    {
+                        errors.Add(error);
+                        break;
+                    }
                     else
                     {
+                        errors.Add(error);
                         items = ResultHandlers.CleanFromError(error, items);
                     }
                 }

--- a/ExtractorUtils/queues/RawUploadQueue.cs
+++ b/ExtractorUtils/queues/RawUploadQueue.cs
@@ -60,7 +60,7 @@ namespace Cognite.Extractor.Utils
             var rows = items.ToDictionary(pair => pair.key, pair => pair.columns);
             if (!rows.Any())
             {
-                return new QueueUploadResult<(string key, T columns)>(Enumerable.Empty<(string key, T columns)>());
+                return new QueueUploadResult<(string key, T columns)>(Enumerable.Empty<(string key, T columns)>(), Enumerable.Empty<(string key, T columns)>());
             }
             DestLogger.LogTrace("Dequeued {Number} {Type} rows to upload to CDF Raw", rows.Count, typeof(T).Name);
             try
@@ -72,7 +72,7 @@ namespace Cognite.Extractor.Utils
                 return new QueueUploadResult<(string key, T columns)>(ex);
             }
             _numberRows.WithLabels(typeof(T).Name).Inc(rows.Count);
-            return new QueueUploadResult<(string key, T columns)>(items);
+            return new QueueUploadResult<(string key, T columns)>(items, Enumerable.Empty<(string key, T columns)>());
         }
     }
 }


### PR DESCRIPTION
 - Better handle fatal errors when retrying.
 - Avoid mixing sync and async in BaseUploadQueue
 - Return the list of failed items to the user, when possible.
 - Make the BaseUploadQueue constructor public