### PR TITLE
Thread-proof authenticators

### DIFF
--- a/Cognite.Testing/ConsoleWrapper.cs
+++ b/Cognite.Testing/ConsoleWrapper.cs
@@ -57,8 +57,8 @@ namespace Cognite.Extractor.Testing
                     _output.WriteLine(_textWriter.ToString());
                 }
                 _textWriter.Dispose();
+                disposed = true;
             }
-            disposed = true;
         }
     }
 }


### PR DESCRIPTION
They are actually a little racy, this should help make them less prone to duplicate token requests.