### PR TITLE
Better remote configuration

### DIFF
--- a/Cognite.Common/ListOrSpaceSeparated.cs
+++ b/Cognite.Common/ListOrSpaceSeparated.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Cognite.Common
+{
+    /// <summary>
+    /// A wrapper for yaml types that are serialized either as lists or as space separated values.
+    /// </summary>
+    public class ListOrSpaceSeparated
+    {
+        /// <summary>
+        /// Inner values
+        /// </summary>
+        public string[] Values { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="values">List of values, will always be serialized as a list</param>
+        public ListOrSpaceSeparated(params string[] values)
+        {
+            Values = values;
+        }
+
+        /// <summary>
+        /// Explicit conversion to string array
+        /// </summary>
+        /// <param name="list">List of values</param>
+        public static implicit operator string[](ListOrSpaceSeparated list) => list?.Values ?? throw new ArgumentNullException(nameof(list));
+    }
+}

--- a/Cognite.Extensions/Authenticator.cs
+++ b/Cognite.Extensions/Authenticator.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Cognite.Extractor.Common;
+using Cognite.Common;
 
 namespace Cognite.Extensions
 {
@@ -37,7 +38,7 @@ namespace Cognite.Extensions
     public class AuthenticatorConfig
     {
         /// <summary>
-        /// Available authenticator implementations 
+        /// DEPRECATED: Available authenticator implementations 
         /// </summary>
         public enum AuthenticatorImplementation
         {
@@ -52,7 +53,7 @@ namespace Cognite.Extensions
         }
 
         /// <summary>
-        /// Which implementation to use in the authenticator (optional)
+        /// DEPRECATED: Which implementation to use in the authenticator (optional)
         /// </summary>
         public AuthenticatorImplementation Implementation { get; set; } = AuthenticatorImplementation.MSAL;
 
@@ -96,7 +97,7 @@ namespace Cognite.Extensions
         /// Resource scopes
         /// </summary>
         /// <value>Scope</value>
-        public IList<string>? Scopes { get; set; }
+        public ListOrSpaceSeparated? Scopes { get; set; }
 
         /// <summary>
         /// Audience
@@ -211,7 +212,7 @@ namespace Cognite.Extensions
                 { "grant_type", "client_credentials" }
             };
 
-            if (_config.Scopes != null && _config.Scopes.Count > 0)
+            if (_config.Scopes != null && _config.Scopes.Values.Length > 0)
             {
                 form["scope"] = string.Join(" ", _config.Scopes);
             }
@@ -244,13 +245,14 @@ namespace Cognite.Extensions
                     }
 
                     _logger.LogDebug(
-                        "New OIDC token. Expires on {ttl}", 
+                        "New OIDC token. Expires on {ttl}",
                         (DateTime.UtcNow + TimeSpan.FromSeconds(tokenResponse.ExpiresIn)).ToISOString());
                     return tokenResponse;
                 }
                 else
                 {
-                    try {
+                    try
+                    {
                         var error = JsonSerializer.Deserialize<ErrorDTO>(body);
                         if (error == null)
                         {
@@ -261,9 +263,9 @@ namespace Cognite.Extensions
                     }
                     catch (JsonException ex)
                     {
-                        _logger.LogError("Unable to obtain OIDC token: R{Code} - {Message}", (int) response.StatusCode, response.ReasonPhrase);
+                        _logger.LogError("Unable to obtain OIDC token: R{Code} - {Message}", (int)response.StatusCode, response.ReasonPhrase);
                         throw new CogniteUtilsException(
-                            $"Could not obtain OIDC token: {(int) response.StatusCode} - {response.ReasonPhrase}",
+                            $"Could not obtain OIDC token: {(int)response.StatusCode} - {response.ReasonPhrase}",
                             ex);
                     }
                 }

--- a/Cognite.Extensions/MsalAuthenticator.cs
+++ b/Cognite.Extensions/MsalAuthenticator.cs
@@ -36,13 +36,14 @@ namespace Cognite.Extensions
         {
             _config = config;
             _logger = logger ?? new NullLogger<MsalAuthenticator>();
-            if (_config != null) {
+            if (_config != null)
+            {
                 Uri authorityUrl;
-                if (_config.Certificate?.AuthorityUrl != null)
+                if (!string.IsNullOrWhiteSpace(_config.Certificate?.AuthorityUrl))
                 {
-                    authorityUrl = new Uri(_config.Certificate.AuthorityUrl);
+                    authorityUrl = new Uri(_config.Certificate!.AuthorityUrl);
                 }
-                else if (_config.Authority != null && _config.Tenant != null)
+                else if (!string.IsNullOrWhiteSpace(_config.Authority) && !string.IsNullOrWhiteSpace(_config.Tenant))
                 {
                     var uriBuilder = new UriBuilder(_config.Authority);
                     uriBuilder.Path = $"{_config.Tenant}";
@@ -57,9 +58,8 @@ namespace Cognite.Extensions
                     .WithHttpClientFactory(new MsalClientFactory(httpClientFactory, authClientName))
                     .WithAuthority(authorityUrl);
 
-                if (_config.Certificate != null)
+                if (_config.Certificate != null && _config.Certificate.Path != null)
                 {
-                    if (_config.Certificate.Path == null) throw new ConfigurationException("Certificate path is required for certificate authentication");
                     var ext = Path.GetExtension(_config.Certificate.Path);
 
                     X509Certificate2 cert;
@@ -122,7 +122,8 @@ namespace Cognite.Extensions
         /// <exception cref="CogniteUtilsException">Thrown when it was not possible to obtain an authentication token.</exception>
         public async Task<string?> GetToken(CancellationToken token = default)
         {
-            if (_config == null || _app == null) {
+            if (_config == null || _app == null)
+            {
                 _logger.LogInformation("OIDC authentication disabled.");
                 return null;
             }
@@ -130,14 +131,15 @@ namespace Cognite.Extensions
             await _mutex.WaitAsync(token).ConfigureAwait(false);
             try
             {
-                var result = await _app.AcquireTokenForClient(_config.Scopes)
+                var result = await _app.AcquireTokenForClient(_config.Scopes?.Values)
                     .ExecuteAsync(token).ConfigureAwait(false);
-                
+
                 // The client application will take care of caching the token and 
                 // renewal before expiration
-                if (result.ExpiresOn != _lastTokenTime) {
+                if (result.ExpiresOn != _lastTokenTime)
+                {
                     _logger.LogDebug(
-                        "New OIDC token. Expires on {ttl}", 
+                        "New OIDC token. Expires on {ttl}",
                         result.ExpiresOn.UtcDateTime.ToISOString());
                     _lastTokenTime = result.ExpiresOn;
                 }

--- a/Cognite.Extensions/MsalAuthenticator.cs
+++ b/Cognite.Extensions/MsalAuthenticator.cs
@@ -58,7 +58,7 @@ namespace Cognite.Extensions
                     .WithHttpClientFactory(new MsalClientFactory(httpClientFactory, authClientName))
                     .WithAuthority(authorityUrl);
 
-                if (_config.Certificate != null && _config.Certificate.Path != null)
+                if (_config.Certificate?.Path != null)
                 {
                     var ext = Path.GetExtension(_config.Certificate.Path);
 

--- a/ExtractorUtils/Cognite/DestinationUtils.cs
+++ b/ExtractorUtils/Cognite/DestinationUtils.cs
@@ -178,8 +178,8 @@ namespace Cognite.Extractor.Utils
                 var logger = provider.GetRequiredService<ILogger<IAuthenticator>>();
                 var clientFactory = provider.GetRequiredService<IHttpClientFactory>();
 
-                if (!string.IsNullOrWhiteSpace(conf.IdpAuthentication.Tenant.TrimToNull())
-                    && !string.IsNullOrWhiteSpace(conf.IdpAuthentication.Certificate?.Path))
+                if (!string.IsNullOrWhiteSpace(conf.IdpAuthentication.Tenant)
+                    || !string.IsNullOrWhiteSpace(conf.IdpAuthentication.Certificate?.Path))
                 {
                     return new MsalAuthenticator(conf.IdpAuthentication, logger, clientFactory, authClientName);
                 }

--- a/ExtractorUtils/Cognite/DestinationUtils.cs
+++ b/ExtractorUtils/Cognite/DestinationUtils.cs
@@ -179,7 +179,7 @@ namespace Cognite.Extractor.Utils
                 var clientFactory = provider.GetRequiredService<IHttpClientFactory>();
 
                 if (!string.IsNullOrWhiteSpace(conf.IdpAuthentication.Tenant.TrimToNull())
-                    || conf.IdpAuthentication.Certificate != null)
+                    && !string.IsNullOrWhiteSpace(conf.IdpAuthentication.Certificate?.Path))
                 {
                     return new MsalAuthenticator(conf.IdpAuthentication, logger, clientFactory, authClientName);
                 }

--- a/ExtractorUtils/config/remote_config.yml
+++ b/ExtractorUtils/config/remote_config.yml
@@ -1,0 +1,39 @@
+# Sample configuration file for remote config. This can be used as remote config directly.
+
+cognite:
+    # The project to connect to in the API
+    project: ${COGNITE_PROJECT}
+    # Cognite service url
+    host: ${COGNITE_BASE_URL}
+    # Config for authentication if a bearer access token has to be used for authentication.
+    # Leave empty to disable.
+    idp-authentication:
+        # URL to fetch tokens from, either this, or tenant must be present.
+        token-url: ${COGNITE_TOKEN_URL}
+        # Identity provider authority endpoint (optional, only used in combination with tenant)
+        authority: ${COGNITE_AUTHORITY_URL}
+        # Directory tenant
+        tenant: ${COGNITE_TENANT}
+        # Application Id
+        client-id: ${COGNITE_CLIENT_ID}
+        # Client secret
+        secret: ${COGNITE_CLIENT_SECRET}
+        # List of resource scopes, ex:
+        # scopes:
+        #   - scopeA
+        #   - scopeB
+        scopes: ${COGNITE_SCOPES}
+        # Audience
+        audience: ${COGNITE_AUDIENCE}
+        # Minimum time-to-live in seconds for the token (optional)
+        min-ttl: 30
+        # Configuration for certificate based authentication
+        certificate:
+            # Path to a .pfx or .pem certificate file (.pem only for .NET 7 extractors)
+            path: ${COGNITE_CERTIFICATE_PATH}
+            # Optional certificate key password
+            password: ${COGNITE_CERTIFICATE_PASSWORD}
+            # Optional authority URL. If this is not specified, authority + tenant is used.
+            authority-url: ${COGNITE_CERTIFICATE_AUTHORITY_URL}
+    extraction-pipeline:
+        external-id: ${COGNITE_EXTRACTION_PIPELINE}


### PR DESCRIPTION
Create a config file that can be used for remote config. This also makes a few changes to make that more possible.

 - Allow scopes to be configured either as a list of strings, or as space separated strings.
 - Allow an empty "certificate" block
 - Improve handling of empty values.