### PR TITLE
KeyVault support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,14 +22,14 @@ jobs:
     - name: Build
       run: dotnet build --configuration Debug --no-restore
     - name: Unit Test
-      run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ /p:SolutionDir=$(pwd) --filter ExtractorUtils.Test.Unit. ./ExtractorUtils.Test/
+      run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ --filter ExtractorUtils.Test.Unit. ./ExtractorUtils.Test/
       if: ${{ github.event == 'pull_request' && github.base_ref == 'refs/heads/integration' }}
     - name: Start Redis
       uses: supercharge/redis-github-action@ea9b21c6ecece47bd99595c532e481390ea0f044 # 1.8.0
       with:
         redis-version: 5
     - name: Test
-      run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ /p:SolutionDir=$(pwd) ./ExtractorUtils.Test/
+      run: dotnet test --no-restore --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/ ./ExtractorUtils.Test/
       if: ${{ github.event != 'pull_request' || github.base_ref == 'refs/heads/master' }}
       env:
         TEST_PROJECT: "extractor-tests"
@@ -44,6 +44,9 @@ jobs:
         BF_TEST_CLIENT_ID: ${{ secrets.BF_TEST_CLIENT_ID }}
         BF_TEST_TENANT: ${{ secrets.BF_TEST_TENANT }}
         BF_TEST_SECRET: ${{ secrets.BF_TEST_SECRET }}
+        KEYVAULT_CLIENT_ID: ${{ secrets.KEYVAULT_CLIENT_ID }}
+        KEYVAULT_CLIENT_SECRET: ${{ secrets.KEYVAULT_CLIENT_SECRET }}
+        KEYVAULT_TENANT_ID: ${{ secrets.KEYVAULT_TENANT_ID }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/Cognite.Common/Cognite.Common.csproj
+++ b/Cognite.Common/Cognite.Common.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/Cognite.Config/Cognite.Configuration.csproj
+++ b/Cognite.Config/Cognite.Configuration.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
@@ -25,6 +25,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />

--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -564,9 +564,9 @@ namespace Cognite.Extractor.Configuration
 
             if (values.TryGetValue(scalar.Value, out var enumMember))
             {
-                return Enum.Parse(type, enumMember.Name);
+                return Enum.Parse(type, enumMember.Name, true);
             }
-            return Enum.Parse(type, scalar.Value);
+            return Enum.Parse(type, scalar.Value, true);
         }
 
         public void WriteYaml(IEmitter emitter, object? value, Type type)

--- a/Cognite.Config/Configuration.cs
+++ b/Cognite.Config/Configuration.cs
@@ -199,7 +199,7 @@ namespace Cognite.Extractor.Configuration
             int configVersion = GetVersionFromString(yaml);
             CheckVersion(configVersion, acceptedConfigVersions);
 
-            var config = ReadString<T>(yaml);
+            var config = ReadString<T>(yaml, ignoreUnmatched);
             config.GenerateDefaults();
             return config;
         }
@@ -223,7 +223,7 @@ namespace Cognite.Extractor.Configuration
             int configVersion = GetVersionFromFile(path);
             CheckVersion(configVersion, acceptedConfigVersions);
 
-            var config = Read<T>(path);
+            var config = Read<T>(path, ignoreUnmatched);
             config.GenerateDefaults();
             return config;
         }

--- a/Cognite.Config/KeyVault.cs
+++ b/Cognite.Config/KeyVault.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Runtime.Serialization;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Configuration;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Cognite.Extractor.KeyVault
+{
+    /// <summary>
+    /// Method used to authenticate against azure.
+    /// </summary>
+    public enum KeyVaultAuthenticationMethod
+    {
+        /// <summary>
+        /// Authenticate using client secret credentials.
+        /// </summary>
+        [EnumMember(Value = "client-secret")]
+        ClientSecret,
+        /// <summary>
+        /// Authenticate using machine default credentials.
+        /// </summary>
+        [EnumMember(Value = "default")]
+        Default,
+    }
+
+
+    /// <summary>
+    /// Configuration for azure key vault.
+    /// </summary>
+    public class KeyVaultConfig
+    {
+        /// <summary>
+        /// How to authenticate against key vault.
+        /// </summary>
+        public KeyVaultAuthenticationMethod? AuthenticationMethod { get; set; }
+        /// <summary>
+        /// Azure key vault name.
+        /// </summary>
+        public string? VaultName { get; set; }
+        /// <summary>
+        /// Azure tenant ID.
+        /// </summary>
+        public string? TenantId { get; set; }
+        /// <summary>
+        /// Azure client id.
+        /// </summary>
+        public string? ClientId { get; set; }
+        /// <summary>
+        /// Azure client secret.
+        /// </summary>
+        public string? Secret { get; set; }
+
+        private SecretClient? _client;
+
+        /// <summary>
+        /// Get a client singleton owned by this config.
+        /// </summary>
+        /// <returns></returns>
+        public SecretClient GetClient()
+        {
+            if (_client != null)
+            {
+                return _client;
+            }
+
+            TokenCredential? credentials = null;
+
+            if (AuthenticationMethod == KeyVaultAuthenticationMethod.Default)
+            {
+                credentials = new DefaultAzureCredential();
+            }
+            else if (AuthenticationMethod == KeyVaultAuthenticationMethod.ClientSecret)
+            {
+                if (string.IsNullOrWhiteSpace(VaultName)) throw new ConfigurationException("Missing KeyVault vault name");
+                if (string.IsNullOrWhiteSpace(TenantId)) throw new ConfigurationException("Missing KeyVault tenant ID");
+                if (string.IsNullOrWhiteSpace(ClientId)) throw new ConfigurationException("Missing KeyVault client ID");
+                if (string.IsNullOrWhiteSpace(Secret)) throw new ConfigurationException("Missing KeyVault client secret");
+                credentials = new ClientSecretCredential(
+                    TenantId,
+                    ClientId,
+                    Secret
+                );
+            }
+
+
+            if (credentials == null) throw new ConfigurationException("Missing authentication-method in KeyVault config");
+
+            _client = new SecretClient(
+                new Uri($"https://{VaultName}.vault.azure.net"),
+                credentials
+            );
+            return _client;
+        }
+
+        /// <summary>
+        /// Add a key vault node deserializer and tag mapping to a yaml deserializer builder.
+        /// </summary>
+        /// <param name="builder">Builder to add key vault support to</param>
+        internal void AddKeyVault(DeserializerBuilder builder)
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            try
+            {
+                builder.WithoutNodeDeserializer(typeof(KeyVaultResolver));
+            }
+            catch { }
+
+            builder.WithNodeDeserializer(new KeyVaultResolver(this));
+        }
+    }
+
+    internal class KeyVaultResolver : INodeDeserializer
+    {
+        private SecretClient _client;
+
+        public KeyVaultResolver(KeyVaultConfig config)
+        {
+            _client = config.GetClient();
+        }
+        public bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+        {
+            if (reader.Accept<Scalar>(out var scalar)
+                && scalar != null
+                && !scalar.Tag.IsEmpty
+                && scalar.Tag.Value == "!keyvault")
+            {
+                reader.MoveNext();
+
+                var secretValue = _client.GetSecret(scalar.Value);
+                value = secretValue.Value.Value;
+                return true;
+            }
+            value = null;
+            return false;
+        }
+    }
+}

--- a/Cognite.Config/KeyVault.cs
+++ b/Cognite.Config/KeyVault.cs
@@ -77,7 +77,7 @@ namespace Cognite.Extractor.KeyVault
             }
             else if (AuthenticationMethod == KeyVaultAuthenticationMethod.ClientSecret)
             {
-                if (string.IsNullOrWhiteSpace(KeyvaultName)) throw new ConfigurationException("Missing KeyVault vault name");
+                if (string.IsNullOrWhiteSpace(KeyVaultName)) throw new ConfigurationException("Missing KeyVault vault name");
                 if (string.IsNullOrWhiteSpace(TenantId)) throw new ConfigurationException("Missing KeyVault tenant ID");
                 if (string.IsNullOrWhiteSpace(ClientId)) throw new ConfigurationException("Missing KeyVault client ID");
                 if (string.IsNullOrWhiteSpace(Secret)) throw new ConfigurationException("Missing KeyVault client secret");
@@ -92,7 +92,7 @@ namespace Cognite.Extractor.KeyVault
             if (credentials == null) throw new ConfigurationException("Missing authentication-method in KeyVault config");
 
             _client = new SecretClient(
-                new Uri($"https://{KeyvaultName}.vault.azure.net"),
+                new Uri($"https://{KeyVaultName}.vault.azure.net"),
                 credentials
             );
             return _client;

--- a/Cognite.Config/KeyVault.cs
+++ b/Cognite.Config/KeyVault.cs
@@ -41,7 +41,8 @@ namespace Cognite.Extractor.KeyVault
         /// <summary>
         /// Azure key vault name.
         /// </summary>
-        public string? VaultName { get; set; }
+        [YamlMember(Alias = "keyvault-name")]
+        public string? KeyVaultName { get; set; }
         /// <summary>
         /// Azure tenant ID.
         /// </summary>
@@ -76,7 +77,7 @@ namespace Cognite.Extractor.KeyVault
             }
             else if (AuthenticationMethod == KeyVaultAuthenticationMethod.ClientSecret)
             {
-                if (string.IsNullOrWhiteSpace(VaultName)) throw new ConfigurationException("Missing KeyVault vault name");
+                if (string.IsNullOrWhiteSpace(KeyvaultName)) throw new ConfigurationException("Missing KeyVault vault name");
                 if (string.IsNullOrWhiteSpace(TenantId)) throw new ConfigurationException("Missing KeyVault tenant ID");
                 if (string.IsNullOrWhiteSpace(ClientId)) throw new ConfigurationException("Missing KeyVault client ID");
                 if (string.IsNullOrWhiteSpace(Secret)) throw new ConfigurationException("Missing KeyVault client secret");
@@ -91,7 +92,7 @@ namespace Cognite.Extractor.KeyVault
             if (credentials == null) throw new ConfigurationException("Missing authentication-method in KeyVault config");
 
             _client = new SecretClient(
-                new Uri($"https://{VaultName}.vault.azure.net"),
+                new Uri($"https://{KeyvaultName}.vault.azure.net"),
                 credentials
             );
             return _client;

--- a/Cognite.Config/VersionedConfig.cs
+++ b/Cognite.Config/VersionedConfig.cs
@@ -1,24 +1,30 @@
-namespace Cognite.Extractor.Configuration 
+using Cognite.Extractor.KeyVault;
+
+namespace Cognite.Extractor.Configuration
 {
-    
+
     /// <summary>
     /// Base configuration object for supporting versioned configuration.
     /// The config should have a version property, so that versioning and compatibility can be tracked.
     /// </summary>
-    public abstract class VersionedConfig 
+    public abstract class VersionedConfig
     {
-        
+
         /// <summary>
         /// Current version of this config object
         /// </summary>
         public int Version { get; set; }
 
         /// <summary>
+        /// Key vault configuration
+        /// </summary>
+        public KeyVaultConfig? KeyVault { get; set; }
+
+        /// <summary>
         /// Should be implemented in Base classes to initialize properties with default
         /// values, in case the values were not present in the parsed yaml config
         /// </summary>
         public abstract void GenerateDefaults();
-
     }
 
 }

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -16,7 +16,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/Cognite.Logging/Cognite.Logging.csproj
+++ b/Cognite.Logging/Cognite.Logging.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/Cognite.Metrics/Cognite.Metrics.csproj
+++ b/Cognite.Metrics/Cognite.Metrics.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/Cognite.StateStorage/Cognite.StateStorage.csproj
+++ b/Cognite.StateStorage/Cognite.StateStorage.csproj
@@ -17,7 +17,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/Cognite.Testing/Cognite.Testing.csproj
+++ b/Cognite.Testing/Cognite.Testing.csproj
@@ -18,7 +18,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
 

--- a/ExtractorUtils.Test/ExtractorUtils.Test.csproj
+++ b/ExtractorUtils.Test/ExtractorUtils.Test.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
-	<AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+	<AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
 	<SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/ExtractorUtils.Test/unit/ConfigurationTest.cs
+++ b/ExtractorUtils.Test/unit/ConfigurationTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using Cognite.Common;
 using Cognite.Extractor.Common;
 using Cognite.Extractor.Configuration;
@@ -39,6 +41,13 @@ namespace ExtractorUtils.Test.Unit
             if (Foo == null) Foo = "";
             if (Bar == null) Bar = "default";
         }
+    }
+
+    enum TestEnum
+    {
+        [EnumMember(Value = "not-foo-at-all")]
+        Foo,
+        Bar,
     }
 
     public static class ConfigurationTest
@@ -431,6 +440,16 @@ custom-config:
     some-value: Some Value
 version: 1
 ", str);
+        }
+
+        [Fact]
+        public static void TestEnumConversion()
+        {
+            Assert.Equal(TestEnum.Foo, ConfigurationUtils.ReadString<TestEnum>("not-foo-at-all"));
+            Assert.Equal(TestEnum.Foo, ConfigurationUtils.ReadString<TestEnum>("foo"));
+            Assert.Equal(TestEnum.Foo, ConfigurationUtils.ReadString<TestEnum>("FOO"));
+            Assert.Equal(TestEnum.Foo, ConfigurationUtils.ReadString<TestEnum>("Foo"));
+            Assert.Equal(TestEnum.Bar, ConfigurationUtils.ReadString<TestEnum>("bar"));
         }
     }
 }

--- a/ExtractorUtils.Test/unit/ConfigurationTest.cs
+++ b/ExtractorUtils.Test/unit/ConfigurationTest.cs
@@ -277,7 +277,7 @@ namespace ExtractorUtils.Test.Unit
                 "baz: !keyvault test-secret",
                 "key-vault:",
                 "    authentication-method: client-secret",
-                "    vault-name: extractor-keyvault",
+                "    keyvault-name: extractor-keyvault",
                 "    tenant-id: ${KEYVAULT_TENANT_ID}",
                 "    client-id: ${KEYVAULT_CLIENT_ID}",
                 "    secret: ${KEYVAULT_CLIENT_SECRET}"

--- a/ExtractorUtils.Test/unit/ConfigurationTest.cs
+++ b/ExtractorUtils.Test/unit/ConfigurationTest.cs
@@ -15,11 +15,16 @@ using Xunit;
 namespace ExtractorUtils.Test.Unit
 {
 #pragma warning disable CA1812
-    class TestConfig
+    class TestConfig : VersionedConfig
 #pragma warning restore CA1812
     {
         public string Foo { get; set; } = "";
         public int Bar { get; set; }
+        public string Baz { get; set; }
+
+        public override void GenerateDefaults()
+        {
+        }
     }
 
     class TestBaseConfig : BaseConfig
@@ -252,6 +257,30 @@ namespace ExtractorUtils.Test.Unit
             File.Delete(path1);
             File.Delete(path2);
             File.Delete(path3);
+        }
+
+        [Fact]
+        public static void TestKeyVault()
+        {
+            var lines = new[] {
+                "version: 1",
+                "foo: !keyvault test-id",
+                "baz: !keyvault test-secret",
+                "key-vault:",
+                "    authentication-method: client-secret",
+                "    vault-name: extractor-keyvault",
+                "    tenant-id: ${KEYVAULT_TENANT_ID}",
+                "    client-id: ${KEYVAULT_CLIENT_ID}",
+                "    secret: ${KEYVAULT_CLIENT_SECRET}"
+            };
+            string path = "test-keyvault-config.yml";
+
+            File.WriteAllLines(path, lines);
+            var services = new ServiceCollection();
+            var res = ConfigurationExtensions.AddConfig<TestConfig>(services, path);
+
+            Assert.Equal("12345", res.Foo);
+            Assert.Equal("abcde", res.Baz);
         }
 
         public class ExtendedCogniteConfig : CogniteConfig

--- a/ExtractorUtils/Configuration/Configuration.cs
+++ b/ExtractorUtils/Configuration/Configuration.cs
@@ -28,18 +28,10 @@ namespace Cognite.Extractor.Utils
 
         private static void TryAddKeyVault(string path)
         {
-            ConfigurationUtils.IgnoreUnmatchedProperties();
-            try
+            var keyVaultConfig = ConfigurationUtils.TryReadConfigFromFile<KeyVaultConfigWrapper>(path, true);
+            if (keyVaultConfig.KeyVault != null)
             {
-                var keyVaultConfig = ConfigurationUtils.TryReadConfigFromFile<KeyVaultConfigWrapper>(path);
-                if (keyVaultConfig.KeyVault != null)
-                {
-                    ConfigurationUtils.AddKeyVault(keyVaultConfig.KeyVault);
-                }
-            }
-            finally
-            {
-                ConfigurationUtils.DisallowUnmatchedProperties();
+                ConfigurationUtils.AddKeyVault(keyVaultConfig.KeyVault);
             }
         }
 
@@ -156,15 +148,7 @@ namespace Cognite.Extractor.Utils
             if (remoteConfig == null)
             {
                 if (path == null) throw new ConfigurationException("No config object specified, config file path is required");
-                ConfigurationUtils.IgnoreUnmatchedProperties();
-                try
-                {
-                    remoteConfig = ConfigurationUtils.TryReadConfigFromFile<RemoteConfig>(path, null);
-                }
-                finally
-                {
-                    ConfigurationUtils.DisallowUnmatchedProperties();
-                }
+                remoteConfig = ConfigurationUtils.TryReadConfigFromFile<RemoteConfig>(path, true, null);
 
 #pragma warning disable CA1062 // Validate arguments of public methods: bizarre false positive
                 if (remoteConfig.Type == ConfigurationMode.Local)

--- a/ExtractorUtils/ExtractorUtils.csproj
+++ b/ExtractorUtils/ExtractorUtils.csproj
@@ -16,7 +16,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)/strong_name.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../strong_name.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Designed to be as similar as possible to the python version, which required some work.

Among other things, it required a custom enum serializer to let us have aliases. This is a neat addition anyway.

This also makes the snk path relative, since solutiondir often doesn't exist.