### PR TITLE
CheckIn worker

### DIFF
--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.68.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.1" />
-    <PackageReference Include="CogniteSdk" Version="4.13.0" />
+    <PackageReference Include="CogniteSdk" Version="4.13.3" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.1" />

--- a/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Extensions.Unstable;
+using Cognite.Extractor.Utils.Unstable;
+using Cognite.ExtractorUtils.Unstable.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+using Cognite.Extensions;
+using Cognite.Extractor.Testing;
+using Cognite.Extractor.Configuration;
+using Cognite.ExtractorUtils.Unstable;
+using Cognite.Extractor.Utils;
+using Cognite.ExtractorUtils.Unstable.Tasks;
+using Microsoft.Extensions.Logging;
+using CogniteSdk.Alpha;
+
+
+namespace ExtractorUtils.Test.Unit.Unstable
+{
+    public class CheckInWorkerTests
+    {
+        private List<dynamic> taskEvents = new();
+        private List<dynamic> errors = new();
+
+        private int? _lastConfigRevision;
+
+        private readonly ITestOutputHelper _output;
+        private int _checkInCount;
+        public CheckInWorkerTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+
+        private ConnectionConfig GetConfig()
+        {
+            return new ConnectionConfig
+            {
+                Project = "project",
+                BaseUrl = "https://greenfield.cognitedata.com",
+                Integration = "test-integration",
+                Authentication = new ClientCredentialsConfig
+                {
+                    ClientId = "someId",
+                    ClientSecret = "thisIsASecret",
+                    Scopes = new Cognite.Common.ListOrSpaceSeparated("https://greenfield.cognitedata.com/.default"),
+                    MinTtl = "60s",
+                    Resource = "resource",
+                    Audience = "audience",
+                    TokenUrl = "http://example.url/token",
+                }
+            };
+        }
+
+        private (ServiceProvider, CheckInWorker) GetCheckInWorker()
+        {
+            var config = GetConfig();
+            var baseCogniteConfig = new BaseCogniteConfig();
+
+            var services = new ServiceCollection();
+            services.AddConfig(config, typeof(ConnectionConfig));
+            services.AddConfig(baseCogniteConfig, typeof(BaseCogniteConfig));
+            var mocks = TestUtilities.GetMockedHttpClientFactory(mockCheckInAsync);
+            var mockHttpMessageHandler = mocks.handler;
+            var mockFactory = mocks.factory;
+            services.AddSingleton(mockFactory.Object);
+            services.AddTestLogging(_output);
+            DestinationUtilsUnstable.AddCogniteClient(services, "myApp", null, setLogger: true, setMetrics: true, setHttpClient: true);
+            var provider = services.BuildServiceProvider();
+
+            var dest = provider.GetRequiredService<CogniteDestination>();
+
+            return (provider, new CheckInWorker(config.Integration, provider.GetRequiredService<ILogger<CheckInWorker>>(), dest.CogniteClient));
+        }
+
+        [Fact]
+        public async Task TestCheckInWorker()
+        {
+            var (provider, checkIn) = GetCheckInWorker();
+            using var p = provider;
+            using var source = new CancellationTokenSource();
+            // Check that this doesn't crash, and properly cancels out at the end.
+            var runTask = checkIn.Run(source.Token, Timeout.InfiniteTimeSpan);
+            // First, we should very quickly report a checkin on the start of the run task...
+            await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
+
+            // Report an empty checkin.
+            await checkIn.Flush(source.Token);
+            Assert.Equal(2, _checkInCount);
+
+            var start = DateTime.UtcNow;
+            // Report a checkin with some task starts
+            checkIn.ReportTaskStart("task1", null, start);
+            checkIn.ReportTaskStart("task2", null, start);
+            await checkIn.Flush(source.Token);
+            Assert.Equal(3, _checkInCount);
+            Assert.Equal(2, taskEvents.Count);
+            Assert.Equal("task1", (string)taskEvents[0].name);
+            Assert.Equal("started", (string)taskEvents[0].type);
+            Assert.NotNull(taskEvents[0].timestamp);
+
+            _lastConfigRevision = 1;
+
+            // Report some errors
+            checkIn.ReportError(new ExtractorError(ErrorLevel.warning, "test", checkIn, now: start.AddSeconds(1)));
+            checkIn.ReportError(new ExtractorError(ErrorLevel.error, "test", checkIn, now: start.AddSeconds(1)));
+
+            await checkIn.Flush(source.Token);
+            Assert.Equal(4, _checkInCount);
+            Assert.Equal(2, errors.Count);
+
+            // Report some task ends
+            checkIn.ReportTaskEnd("task1", null, start.AddSeconds(2));
+            checkIn.ReportTaskEnd("task2", null, start.AddSeconds(2));
+            await checkIn.Flush(source.Token);
+            Assert.Equal(5, _checkInCount);
+            Assert.Equal(4, taskEvents.Count);
+
+            source.Cancel();
+            await TestUtils.RunWithTimeout(runTask, 5);
+        }
+
+        [Fact]
+        public async Task TestCheckInWorkerBatch()
+        {
+            var (provider, checkIn) = GetCheckInWorker();
+            using var p = provider;
+            using var source = new CancellationTokenSource();
+
+            // Check that this doesn't crash, and properly cancels out at the end.
+            var runTask = checkIn.Run(source.Token, Timeout.InfiniteTimeSpan);
+            // First, we should very quickly report a checkin on the start of the run task...
+            await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
+
+            // Lots of task updates.
+            var start = DateTime.UtcNow;
+            for (int i = 0; i < 1000; i++)
+            {
+                checkIn.ReportTaskStart("task1", null, start.AddSeconds(i));
+                checkIn.ReportTaskEnd("task1", null, start.AddSeconds(i + 1));
+            }
+            // Add errors in wrong order. The one offset by 1 should be written first.
+            checkIn.ReportError(new ExtractorError(ErrorLevel.error, "test", checkIn, now: start.AddSeconds(900)));
+            checkIn.ReportError(new ExtractorError(ErrorLevel.warning, "test", checkIn, now: start.AddSeconds(1)));
+
+            await checkIn.Flush(source.Token);
+            Assert.Equal(3, _checkInCount);
+            Assert.Equal(2000, taskEvents.Count);
+            Assert.Equal(2, errors.Count);
+            Assert.Equal(ErrorLevel.warning, (ErrorLevel)errors[0].level);
+            Assert.Equal(ErrorLevel.error, (ErrorLevel)errors[1].level);
+
+            // Lots of errors
+            taskEvents.Clear();
+            errors.Clear();
+            for (int i = 0; i < 2000; i++)
+            {
+                checkIn.ReportError(new ExtractorError(ErrorLevel.error, "test", checkIn, now: start.AddSeconds(i)));
+            }
+            checkIn.ReportTaskStart("task1", null, start.AddSeconds(1));
+            checkIn.ReportTaskEnd("task1", null, start.AddSeconds(1900));
+            await checkIn.Flush(source.Token);
+            Assert.Equal(5, _checkInCount);
+            Assert.Equal(2, taskEvents.Count);
+            Assert.Equal(2000, errors.Count);
+
+            source.Cancel();
+            await TestUtils.RunWithTimeout(runTask, 5);
+        }
+
+
+        private async Task<HttpResponseMessage> mockCheckInAsync(
+            HttpRequestMessage message,
+            CancellationToken token
+        )
+        {
+            var uri = message.RequestUri.ToString();
+            if (uri == "http://example.url/token")
+            {
+                var reply = "{" + Environment.NewLine +
+                       $"  \"token_type\": \"Bearer\",{Environment.NewLine}" +
+                       $"  \"expires_in\": 2,{Environment.NewLine}" +
+                       $"  \"access_token\": \"token\"{Environment.NewLine}" +
+                        "}";
+                // Return 200
+                var response = new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(reply)
+                };
+
+                return response;
+            }
+
+            Assert.Contains("/integrations/checkin", uri);
+            var content = await message.Content.ReadAsStringAsync(token);
+            _output.WriteLine(content);
+            var data = JsonConvert.DeserializeObject<dynamic>(content);
+            Assert.Equal("test-integration", (string)data.externalId);
+
+            if (data.taskEvents != null)
+            {
+                taskEvents.AddRange(data.taskEvents);
+            }
+            if (data.errors != null)
+            {
+                errors.AddRange(data.errors);
+            }
+            _checkInCount++;
+
+            dynamic resData = new ExpandoObject();
+            resData.lastConfigRevision = _lastConfigRevision;
+            resData.externalId = "test-integration";
+
+            var resBody = JsonConvert.SerializeObject(resData);
+
+            var fresponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(resBody)
+            };
+            fresponse.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            fresponse.Headers.Add("x-request-id", "1");
+
+            return fresponse;
+        }
+    }
+}

--- a/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
@@ -22,12 +22,12 @@ namespace ExtractorUtils.Test.unit.Unstable
             Errors.Add(error);
         }
 
-        public void ReportTaskEnd(string taskName, DateTime? timestamp = null)
+        public void ReportTaskEnd(string taskName, TaskUpdatePayload update = null, DateTime? timestamp = null)
         {
             TaskEnd.Add((taskName, timestamp ?? DateTime.UtcNow));
         }
 
-        public void ReportTaskStart(string taskName, DateTime? timestamp = null)
+        public void ReportTaskStart(string taskName, TaskUpdatePayload update = null, DateTime? timestamp = null)
         {
             TaskStart.Add((taskName, timestamp ?? DateTime.UtcNow));
         }
@@ -43,9 +43,9 @@ namespace ExtractorUtils.Test.unit.Unstable
 
         public override string Name { get; }
 
-        private Func<BaseErrorReporter, CancellationToken, Task> _func;
+        private Func<BaseErrorReporter, CancellationToken, Task<TaskUpdatePayload>> _func;
 
-        public RunQuickTask(string name, Func<BaseErrorReporter, CancellationToken, Task> func)
+        public RunQuickTask(string name, Func<BaseErrorReporter, CancellationToken, Task<TaskUpdatePayload>> func)
         {
             _func = func;
             Name = name;
@@ -56,7 +56,7 @@ namespace ExtractorUtils.Test.unit.Unstable
             return CanRun();
         }
 
-        public override Task Run(BaseErrorReporter task, CancellationToken token)
+        public override Task<TaskUpdatePayload> Run(BaseErrorReporter task, CancellationToken token)
         {
             return _func(task, token);
         }
@@ -86,6 +86,7 @@ namespace ExtractorUtils.Test.unit.Unstable
                 _output.WriteLine("Enter task");
                 await CommonUtils.WaitAsync(evt, Timeout.InfiniteTimeSpan, tok);
                 _output.WriteLine("Exit task");
+                return null;
             });
             sched.AddScheduledTask(task, true);
             var waitTask = sched.WaitForNextEndOfTask("Task1", TimeSpan.FromSeconds(5));
@@ -111,6 +112,7 @@ namespace ExtractorUtils.Test.unit.Unstable
                     _output.WriteLine("Finish task " + c);
                     seq.Add(c);
                     finished[c] = true;
+                    return null;
                 });
                 t.CanRun = () =>
                 {
@@ -165,6 +167,7 @@ namespace ExtractorUtils.Test.unit.Unstable
                 cbs.BeginWarning("Longer warning", "details").Dispose();
                 cbs.Error("Instant error");
                 cbs.BeginError("Longer error", "details").Dispose();
+                return null;
             });
             sched.AddScheduledTask(task, true);
             var waitTask = sched.WaitForNextEndOfTask("Task1", TimeSpan.FromSeconds(5));

--- a/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
+++ b/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Extractor.Common;
+using CogniteSdk;
+using CogniteSdk.Alpha;
+using Microsoft.Extensions.Logging;
+
+namespace Cognite.ExtractorUtils.Unstable.Tasks
+{
+    /// <summary>
+    /// Worker for submitting periodic checkins to the integrations API.
+    /// </summary>
+    public class CheckInWorker : IIntegrationSink
+    {
+        private readonly object _lock = new object();
+        private readonly Dictionary<string, ErrorWithTask> _errors = new Dictionary<string, ErrorWithTask>();
+        private List<TaskUpdate> _taskUpdates = new List<TaskUpdate>();
+        private readonly Client _client;
+
+        private readonly string _integrationId;
+        private readonly ILogger _logger;
+
+        private const int MAX_ERRORS_PER_CHECKIN = 1000;
+        private const int MAX_TASK_UPDATES_PER_CHECKIN = 1000;
+
+        private bool _isRunning;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="integrationId">ID of the integration the worker should write to.</param>
+        /// <param name="logger">Internal logger.</param>
+        /// <param name="client">Cognite client</param>
+        public CheckInWorker(string integrationId, ILogger logger, Client client)
+        {
+            _client = client;
+            _logger = logger;
+            _integrationId = integrationId;
+        }
+
+        /// <summary>
+        /// Start running the checkin worker.
+        /// 
+        /// This may only be called once.
+        /// </summary>
+        /// <param name="token">Cancellation token</param>
+        /// <param name="interval">Interval, defaults to 30 seconds.</param>
+        public async Task Run(CancellationToken token, TimeSpan? interval = null)
+        {
+            lock (_lock)
+            {
+                if (_isRunning) throw new InvalidOperationException("Attempted to start a checkin worker that was already running");
+                _isRunning = true;
+            }
+
+            var rinterval = interval ?? TimeSpan.FromSeconds(30);
+            while (!token.IsCancellationRequested)
+            {
+                var waitTask = Task.Delay(rinterval, token);
+                try
+                {
+                    await Flush(token).ConfigureAwait(false);
+                    await waitTask.ConfigureAwait(false);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+            }
+
+            _isRunning = false;
+        }
+
+        /// <summary>
+        /// Report a checkin immediately, flushing the cache.
+        /// 
+        /// This should be called after terminating everything else, to report a final checkin.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task Flush(CancellationToken token)
+        {
+            // Reporting checkin is safely behind locks, so we can just call report.
+            try
+            {
+                await ReportCheckIn(token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during checkin: {Message}", ex.Message);
+            }
+        }
+
+        private async Task TryWriteCheckIn(IEnumerable<ErrorWithTask> errors, IEnumerable<TaskUpdate> tasks, CancellationToken token)
+        {
+            try
+            {
+                await _client.Alpha.Integrations.CheckInAsync(new CheckInRequest
+                {
+                    ExternalId = _integrationId,
+                    TaskEvents = tasks,
+                    Errors = errors,
+                }, token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                if (ex is ResponseException rex && (rex.Code == 400 || rex.Code == 404))
+                {
+                    _logger.LogError(rex, "CheckIn failed with a 400 status code, this is a bug! Dropping current checkin batch and continuing.");
+                    return;
+                }
+                // If pushing the update failed, keep the updates to try again later.
+                lock (_lock)
+                {
+                    foreach (var err in errors)
+                    {
+                        if (!_errors.ContainsKey(err.ExternalId)) _errors.Add(err.ExternalId, err);
+                    }
+                    _taskUpdates.AddRange(tasks);
+                }
+                throw;
+            }
+        }
+
+        private async Task ReportCheckIn(CancellationToken token)
+        {
+            List<ErrorWithTask> newErrors;
+            List<TaskUpdate> taskUpdates;
+
+            lock (_lock)
+            {
+                newErrors = _errors.Values.ToList();
+                _errors.Clear();
+                taskUpdates = _taskUpdates;
+                _taskUpdates = new List<TaskUpdate>();
+            }
+
+            newErrors.Sort((a, b) => (a.EndTime ?? a.StartTime).CompareTo(b.EndTime ?? b.StartTime));
+            taskUpdates.Sort((a, b) => a.Timestamp.CompareTo(b.Timestamp));
+
+            while (!token.IsCancellationRequested)
+            {
+                if (newErrors.Count <= MAX_ERRORS_PER_CHECKIN && taskUpdates.Count <= MAX_TASK_UPDATES_PER_CHECKIN)
+                {
+                    await TryWriteCheckIn(newErrors, taskUpdates, token).ConfigureAwait(false);
+                    break;
+                }
+
+                var errIdx = 0;
+                var taskIdx = 0;
+
+                // In the (unlikely) case that we have more than 1000 updates, we need to send them in order of the time where they occured,
+                // roughly.
+                while ((errIdx < newErrors.Count || taskIdx < taskUpdates.Count) && errIdx < MAX_ERRORS_PER_CHECKIN && taskIdx < MAX_TASK_UPDATES_PER_CHECKIN)
+                {
+                    var taskTime = taskUpdates.ElementAtOrDefault(taskIdx)?.Timestamp ?? long.MaxValue;
+                    var err = newErrors.ElementAtOrDefault(errIdx);
+                    var errTime = err?.EndTime ?? err?.StartTime ?? long.MaxValue;
+
+                    if (taskTime <= errTime)
+                    {
+                        taskIdx++;
+                    }
+                    if (errTime <= taskTime)
+                    {
+                        errIdx++;
+                    }
+                }
+
+                var errorsBatch = newErrors.Take(errIdx).ToList();
+                var taskBatch = taskUpdates.Take(taskIdx).ToList();
+
+                if (errIdx > 0) newErrors = newErrors.Skip(errIdx).ToList();
+                if (taskIdx > 0) taskUpdates = taskUpdates.Skip(taskIdx).ToList();
+
+                await TryWriteCheckIn(errorsBatch, taskBatch, token).ConfigureAwait(false);
+            }
+        }
+
+
+        /// <inheritdoc />
+        public void ReportError(ExtractorError error)
+        {
+            if (error == null) throw new ArgumentNullException(nameof(error));
+
+            lock (_lock)
+            {
+                _errors[error.ExternalId] = error.ToSdk();
+            }
+        }
+
+        /// <inheritdoc />
+        public void ReportTaskEnd(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null)
+        {
+            if (taskName == null) throw new ArgumentNullException(nameof(taskName));
+            lock (_lock)
+            {
+                _taskUpdates.Add(new TaskUpdate
+                {
+                    Type = TaskUpdateType.ended,
+                    Name = taskName,
+                    Timestamp = (timestamp ?? DateTime.UtcNow).ToUnixTimeMilliseconds(),
+                    Message = update?.Message,
+                });
+            }
+        }
+
+        /// <inheritdoc />
+        public void ReportTaskStart(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null)
+        {
+            if (taskName == null) throw new ArgumentNullException(nameof(taskName));
+            lock (_lock)
+            {
+                _taskUpdates.Add(new TaskUpdate
+                {
+                    Type = TaskUpdateType.started,
+                    Name = taskName,
+                    Timestamp = (timestamp ?? DateTime.UtcNow).ToUnixTimeMilliseconds(),
+                    Message = update?.Message,
+                });
+            }
+        }
+    }
+}

--- a/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
+++ b/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
@@ -195,7 +195,7 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// <inheritdoc />
         public void ReportTaskEnd(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null)
         {
-            if (taskName == null) throw new ArgumentNullException(nameof(taskName));
+            if (string.IsNullOrEmpty(taskName)) throw new ArgumentNullException(nameof(taskName));
             lock (_lock)
             {
                 _taskUpdates.Add(new TaskUpdate
@@ -211,7 +211,7 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// <inheritdoc />
         public void ReportTaskStart(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null)
         {
-            if (taskName == null) throw new ArgumentNullException(nameof(taskName));
+            if (string.IsNullOrEmpty(taskName)) throw new ArgumentNullException(nameof(taskName));
             lock (_lock)
             {
                 _taskUpdates.Add(new TaskUpdate

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -1,4 +1,5 @@
 using System;
+using Cognite.Extractor.Common;
 using CogniteSdk.Alpha;
 
 namespace Cognite.ExtractorUtils.Unstable.Tasks
@@ -104,6 +105,24 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         }
 
         /// <summary>
+        /// Return an ErrorWithTask for writing to the integrations API.
+        /// </summary>
+        /// <returns>ErrorWithTask object</returns>
+        public ErrorWithTask ToSdk()
+        {
+            return new ErrorWithTask
+            {
+                ExternalId = ExternalId,
+                Level = Level,
+                Description = Description,
+                Details = Details,
+                Task = TaskName,
+                StartTime = StartTime.ToUnixTimeMilliseconds(),
+                EndTime = EndTime?.ToUnixTimeMilliseconds(),
+            };
+        }
+
+        /// <summary>
         /// Dispose the error, just calls `Finish`.
         /// </summary>
         protected virtual void Dispose(bool disposing)
@@ -143,15 +162,17 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// Report that a task has ended.
         /// </summary>
         /// <param name="taskName">Name of task that ended.</param>
+        /// <param name="update">Content of the task update.</param>
         /// <param name="timestamp">When the task ended, defaults to current time.</param>
-        void ReportTaskEnd(string taskName, DateTime? timestamp = null);
+        void ReportTaskEnd(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null);
 
         /// <summary>
         /// Report that a task has started.
         /// </summary>
         /// <param name="taskName">Name of task that started.</param>
+        /// <param name="update">Content of the task update.</param>
         /// <param name="timestamp">When the task started, defaults to current time.</param>
-        void ReportTaskStart(string taskName, DateTime? timestamp = null);
+        void ReportTaskStart(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null);
     }
 
     /// <summary>

--- a/ExtractorUtils/Unstable/Tasks/Task.cs
+++ b/ExtractorUtils/Unstable/Tasks/Task.cs
@@ -5,6 +5,26 @@ using CogniteSdk.Alpha;
 namespace Cognite.ExtractorUtils.Unstable.Tasks
 {
     /// <summary>
+    /// Payload for task run.
+    /// </summary>
+    public class TaskUpdatePayload
+    {
+        /// <summary>
+        /// String message.
+        /// </summary>
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="message">Message giving info about task run.</param>
+        public TaskUpdatePayload(string? message = null)
+        {
+            Message = message;
+        }
+    }
+
+    /// <summary>
     /// Type handling reporting of events related to a single task.
     /// </summary>
     public class TaskReporter : BaseErrorReporter
@@ -36,21 +56,23 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// <summary>
         /// Report that this task has started.
         /// </summary>
+        /// <param name="update">Message and context tied to task run</param>
         /// <param name="timestamp"></param>
-        public void ReportStart(DateTime? timestamp = null)
+        public void ReportStart(TaskUpdatePayload? update = null, DateTime? timestamp = null)
         {
             if (Interlocked.CompareExchange(ref _isRunning, 1, 0) == 1) throw new InvalidOperationException("Attempted to start task that is already running");
-            _sink.ReportTaskStart(TaskName, timestamp);
+            _sink.ReportTaskStart(TaskName, update, timestamp);
         }
 
         /// <summary>
         /// Report that this task has ended.
         /// </summary>
+        /// <param name="update">Message and context tied to task run</param>
         /// <param name="timestamp"></param>
-        public void ReportEnd(DateTime? timestamp = null)
+        public void ReportEnd(TaskUpdatePayload? update = null, DateTime? timestamp = null)
         {
             if (Interlocked.CompareExchange(ref _isRunning, 0, 1) == 0) throw new InvalidOperationException("Attempted to end task that is not running");
-            _sink.ReportTaskEnd(TaskName, timestamp);
+            _sink.ReportTaskEnd(TaskName, update, timestamp);
         }
     }
 }


### PR DESCRIPTION
Class that periodically writes CheckIns to the integrations API.

Includes some slightly clever logic to deal with issues if there are more than 1000 task updates or errors in a single request, hopefully avoiding issues where we get sporadic 400s due to weird ordering on the task requests.