### PR TITLE
Base extractor

### DIFF
--- a/ExtractorUtils.Test/unit/Unstable/BaseExtractorTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/BaseExtractorTest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Testing;
+using Cognite.Extractor.Utils;
+using Cognite.ExtractorUtils.Unstable;
+using Cognite.ExtractorUtils.Unstable.Tasks;
+using ExtractorUtils.Test.unit.Unstable;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ExtractorUtils.Test.Unit.Unstable
+{
+    class DummyConfig { }
+
+    class DummyExtractor : Cognite.ExtractorUtils.Unstable.BaseExtractor<DummyConfig>
+    {
+        public Action<ExtractorTaskScheduler> InitAction { get; set; }
+
+        public DummyExtractor(
+            DummyConfig config,
+            IServiceProvider provider,
+            ExtractorTaskScheduler taskScheduler,
+            IIntegrationSink sink,
+            CogniteDestination destination = null) : base(config, provider,
+            taskScheduler, sink, destination)
+        {
+        }
+
+        public void AddMonitoredTaskPub(Task task, ExtractorTaskResult staticResult, string name)
+        {
+            AddMonitoredTask(task, staticResult, name);
+        }
+
+        protected override Task InitTasks()
+        {
+            InitAction?.Invoke(TaskScheduler);
+            return Task.CompletedTask;
+        }
+    }
+
+    public class BaseExtractorTest
+    {
+        private readonly ITestOutputHelper _output;
+        public BaseExtractorTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private (DummyExtractor, DummySink) CreateExtractor()
+        {
+            var sink = new DummySink();
+            var services = new ServiceCollection();
+            services.AddSingleton(new DummyConfig());
+            services.AddSingleton<IIntegrationSink>(sink);
+            services.AddTestLogging(_output);
+            services.AddTransient<ExtractorTaskScheduler>();
+            services.AddTransient<DummyExtractor>();
+            var provider = services.BuildServiceProvider();
+            return (provider.GetRequiredService<DummyExtractor>(), sink);
+        }
+
+        [Fact]
+        public async Task TestBaseExtractor()
+        {
+            var (ext, sink) = CreateExtractor();
+            var taskCompletedEvent = new ManualResetEvent(false);
+            // Run the extractor and verify that scheduled tasks are run.
+            ext.InitAction = (sched) =>
+            {
+                sched.AddScheduledTask(new RunQuickTask("task1", async (task, token) =>
+                {
+                    await Task.Delay(100, token);
+                    taskCompletedEvent.Set();
+                    return new TaskUpdatePayload();
+                }), true);
+            };
+            var runTask = ext.Start(CancellationToken.None);
+            Assert.True(await CommonUtils.WaitAsync(taskCompletedEvent, TimeSpan.FromSeconds(2), CancellationToken.None));
+            await ext.DisposeAsync();
+
+            Assert.Single(sink.TaskStart);
+            Assert.Single(sink.TaskEnd);
+            Assert.Empty(sink.Errors);
+        }
+
+        [Fact]
+        public async Task TestBaseExtractorInnerError()
+        {
+            var (ext, sink) = CreateExtractor();
+            var taskCompletedEvent = new ManualResetEvent(false);
+            // Run the extractor and verify that scheduled tasks are run.
+            ext.InitAction = (sched) =>
+            {
+                sched.AddScheduledTask(new RunQuickTask("task1", async (task, token) =>
+                {
+                    await Task.Delay(100, token);
+                    taskCompletedEvent.Set();
+                    throw new Exception("Inner error");
+                }), true);
+            };
+            var runTask = ext.Start(CancellationToken.None);
+            Assert.True(await CommonUtils.WaitAsync(taskCompletedEvent, TimeSpan.FromSeconds(2), CancellationToken.None));
+            await ext.DisposeAsync();
+
+            Assert.Single(sink.TaskStart);
+            Assert.Single(sink.TaskEnd);
+            Assert.Equal(2, sink.Errors.Count);
+            Assert.Equal("Inner error", sink.Errors[0].Description);
+        }
+
+        [Fact]
+        public async Task TestBaseExtractorMonitoredError()
+        {
+            var (ext, sink) = CreateExtractor();
+            ext.AddMonitoredTaskPub(Task.Run(async () =>
+            {
+                await Task.Delay(100);
+                throw new Exception("Monitored error");
+            }), ExtractorTaskResult.Unexpected, "task1");
+            var delayTask = Task.Delay(2000);
+            Assert.NotEqual(delayTask, await Task.WhenAny(ext.Start(CancellationToken.None), delayTask));
+            Assert.Equal(2, sink.Errors.Count);
+            Assert.Equal("Internal task task1 failed, restarting extractor: Monitored error", sink.Errors[0].Description);
+        }
+
+        [Fact]
+        public async Task TestBaseExtractorUnexpectedExit()
+        {
+            var (ext, sink) = CreateExtractor();
+            ext.AddMonitoredTaskPub(Task.Run(async () =>
+            {
+                await Task.Delay(100);
+            }), ExtractorTaskResult.Unexpected, "task1");
+            var delayTask = Task.Delay(2000);
+            Assert.NotEqual(delayTask, await Task.WhenAny(ext.Start(CancellationToken.None), delayTask));
+            Assert.Equal(2, sink.Errors.Count);
+            Assert.Equal("Internal task task1 completed, but was not expected to stop, restarting extractor.", sink.Errors[0].Description);
+        }
+    }
+}

--- a/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
@@ -88,7 +88,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
             using var p = provider;
             using var source = new CancellationTokenSource();
             // Check that this doesn't crash, and properly cancels out at the end.
-            var runTask = checkIn.Run(source.Token, Timeout.InfiniteTimeSpan);
+            var runTask = checkIn.RunPeriodicCheckin(source.Token, Timeout.InfiniteTimeSpan);
             // First, we should very quickly report a checkin on the start of the run task...
             await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
 
@@ -136,7 +136,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
             using var source = new CancellationTokenSource();
 
             // Check that this doesn't crash, and properly cancels out at the end.
-            var runTask = checkIn.Run(source.Token, Timeout.InfiniteTimeSpan);
+            var runTask = checkIn.RunPeriodicCheckin(source.Token, Timeout.InfiniteTimeSpan);
             // First, we should very quickly report a checkin on the start of the run task...
             await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
 

--- a/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
@@ -42,7 +42,7 @@ namespace ExtractorUtils.Test.unit.Unstable
             TaskStart.Add((taskName, timestamp ?? DateTime.UtcNow));
         }
 
-        public async Task Run(CancellationToken token, TimeSpan? interval = null)
+        public async Task RunPeriodicCheckin(CancellationToken token, TimeSpan? interval = null)
         {
             while (!token.IsCancellationRequested) await Task.Delay(100000, token);
         }

--- a/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Cognite.Extractor.Common;
 using Cognite.ExtractorUtils.Unstable.Tasks;
 using CogniteSdk.Alpha;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,6 +16,11 @@ namespace ExtractorUtils.Test.unit.Unstable
         public List<ExtractorError> Errors { get; } = new();
         public List<(string, DateTime)> TaskStart { get; } = new();
         public List<(string, DateTime)> TaskEnd { get; } = new();
+
+        public Task Flush(CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
 
         public override ExtractorError NewError(ErrorLevel level, string description, string details = null, DateTime? now = null)
         {
@@ -34,6 +40,11 @@ namespace ExtractorUtils.Test.unit.Unstable
         public void ReportTaskStart(string taskName, TaskUpdatePayload update = null, DateTime? timestamp = null)
         {
             TaskStart.Add((taskName, timestamp ?? DateTime.UtcNow));
+        }
+
+        public async Task Run(CancellationToken token, TimeSpan? interval = null)
+        {
+            while (!token.IsCancellationRequested) await Task.Delay(100000, token);
         }
     }
 
@@ -78,7 +89,7 @@ namespace ExtractorUtils.Test.unit.Unstable
         public async Task TestScheduler()
         {
             var sink = new DummySink();
-            using var sched = new ExtractorTaskScheduler(sink);
+            using var sched = new ExtractorTaskScheduler(sink, new NullLogger<ExtractorTaskScheduler>());
             using var source = new CancellationTokenSource();
 
             var running = sched.Run(source.Token);
@@ -157,7 +168,7 @@ namespace ExtractorUtils.Test.unit.Unstable
         public async Task TestSchedulerErrors()
         {
             var sink = new DummySink();
-            using var sched = new ExtractorTaskScheduler(sink);
+            using var sched = new ExtractorTaskScheduler(sink, new NullLogger<ExtractorTaskScheduler>());
             using var source = new CancellationTokenSource();
 
             var running = sched.Run(source.Token);
@@ -197,7 +208,7 @@ namespace ExtractorUtils.Test.unit.Unstable
         public async Task TestSchedulerFatalError()
         {
             var sink = new DummySink();
-            using var sched = new ExtractorTaskScheduler(sink);
+            using var sched = new ExtractorTaskScheduler(sink, new NullLogger<ExtractorTaskScheduler>());
             using var source = new CancellationTokenSource();
 
             var running = sched.Run(source.Token);

--- a/ExtractorUtils/Unstable/BaseExtractor.cs
+++ b/ExtractorUtils/Unstable/BaseExtractor.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Extractor.Common;
+using Cognite.Extractor.Utils;
+using Cognite.ExtractorUtils.Unstable.Tasks;
+using CogniteSdk.Alpha;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cognite.ExtractorUtils.Unstable
+{
+
+    /// <summary>
+    /// Result of a long-running extractor task.
+    /// 
+    /// Used to indicate whether a task is expected to exit, and whether
+    /// an exit should be considered the extractor crashing.
+    /// </summary>
+    public enum ExtractorTaskResult
+    {
+        /// <summary>
+        /// Task was expected to shut down.
+        /// </summary>
+        Expected,
+        /// <summary>
+        /// Task should not have shut down.
+        /// </summary>
+        Unexpected,
+    }
+
+    /// <summary>
+    /// Class wrapping a task being monitored by the extractor.
+    /// This is simply a way to run background tasks without
+    /// running them as actual extractor tasks reported to
+    /// integrations.
+    /// </summary>
+    class MonitoredTask
+    {
+        /// <summary>
+        /// Task to monitor.
+        /// </summary>
+        public Task<ExtractorTaskResult> Task { get; }
+        /// <summary>
+        /// Task name, does not have to be unique.
+        /// </summary>
+        public string Name { get; }
+
+        public MonitoredTask(Task<ExtractorTaskResult> task, string name)
+        {
+            Task = task;
+            Name = name;
+        }
+    }
+
+    /// <summary>
+    /// Base class for extractors.
+    /// </summary>
+    /// <typeparam name="TConfig">Config type.</typeparam>
+    public abstract class BaseExtractor<TConfig> : BaseErrorReporter, IAsyncDisposable
+    {
+        /// <summary>
+        /// Configuration object
+        /// </summary>
+        protected TConfig Config { get; }
+        /// <summary>
+        /// CDF destination
+        /// </summary>
+        protected CogniteDestination? Destination { get; }
+        private readonly List<MonitoredTask> _monitoredTaskList = new List<MonitoredTask>();
+        private readonly IIntegrationSink _sink;
+
+        /// <summary>
+        /// Task scheduler containing all public extractor tasks.
+        /// </summary>
+        protected ExtractorTaskScheduler TaskScheduler { get; }
+
+        /// <summary>
+        /// Access to the service provider this extractor was built from
+        /// </summary>
+        protected IServiceProvider Provider { get; private set; }
+
+        /// <summary>
+        /// Cancellation token source
+        /// </summary>
+        protected CancellationTokenSource Source { get; set; } = null!;
+
+        private readonly ILogger<BaseExtractor<TConfig>> _logger;
+
+        private object _lock = new object();
+
+        private ManualResetEvent _triggerEvent = new ManualResetEvent(false);
+
+
+        /// <summary>
+        /// Constructor, usable with dependency injection.
+        /// </summary>
+        /// <param name="config">Configuration object</param>
+        /// <param name="provider">Service provider used to build this</param>
+        /// <param name="taskScheduler">Task scheduler.</param>
+        /// <param name="sink">Sink for extractor task updates and errors.</param>
+        /// <param name="destination">Cognite destination.</param>
+        public BaseExtractor(
+            TConfig config,
+            IServiceProvider provider,
+            ExtractorTaskScheduler taskScheduler,
+            IIntegrationSink sink,
+            CogniteDestination? destination = null
+        )
+        {
+            Config = config;
+            Destination = destination;
+            Provider = provider;
+            _sink = sink;
+            TaskScheduler = taskScheduler;
+            _logger = provider.GetService<ILogger<BaseExtractor<TConfig>>>() ?? new NullLogger<BaseExtractor<TConfig>>();
+        }
+
+        /// <summary>
+        /// Initialize the extractor, adding tasks to the
+        /// task runner as needed.
+        /// 
+        /// This runs _before_ the extractor reports startup, if you
+        /// have complex or heavy startup tasks, they should run
+        /// in one or more tasks in the task scheduler, set to run
+        /// immediately on startup.
+        /// 
+        /// The task runner is not started yet when this method is called.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract Task InitTasks();
+
+        private void InitBase(CancellationToken token)
+        {
+            if (Source != null) throw new InvalidOperationException("Extractor already started");
+            Source = CancellationTokenSource.CreateLinkedTokenSource(token);
+        }
+
+        /// <summary>
+        /// Add a task that should be watched by the extractor.
+        /// 
+        /// Use this for tasks that should not be reported to integrations,
+        /// but that you still want to monitor, so that the extractor can crash
+        /// if they fail or exit unexpectedly.
+        /// </summary>
+        /// <param name="task">Task to monitor.</param>
+        /// <param name="name">Task name, just used for logging.</param>
+        protected void AddMonitoredTask(Task<ExtractorTaskResult> task, string name)
+        {
+            if (task == null) throw new ArgumentNullException(nameof(task));
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            lock (_lock)
+            {
+                _monitoredTaskList.Add(new MonitoredTask(task, name));
+                _triggerEvent.Set();
+            }
+        }
+
+        /// <summary>
+        /// Add a monitored task that should be watched by the extractor.
+        /// 
+        /// Use this for tasks that should not be reported to integrations,
+        /// but that you still want to monitor, so that the extractor can crash
+        /// if they fail or exit unexpectedly.
+        /// 
+        /// This variant takes a static ExtractorTaskResult, to indicate whether the
+        /// task is expected to terminate on its own or not.
+        /// </summary>
+        /// <param name="task">Task to monitor.</param>
+        /// <param name="staticResult">Whether the task exiting on its own without cancellation
+        /// should be considered an error.</param>
+        /// <param name="name">Task name, just used for logging.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        protected void AddMonitoredTask(Task task, ExtractorTaskResult staticResult, string name)
+        {
+            if (task == null) throw new ArgumentNullException(nameof(task));
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            lock (_lock)
+            {
+                _monitoredTaskList.Add(new MonitoredTask(Task.Run(async () =>
+                {
+                    await task.ConfigureAwait(false);
+                    return staticResult;
+                }), name));
+                _triggerEvent.Set();
+            }
+        }
+
+
+        private bool _initialized;
+        /// <summary>
+        /// Initialize the extractor, if it has not already been initialized.
+        /// 
+        /// This is called automatically if you call Start, so only use this if you need to separate
+        /// the init stage from the run stage, for example for testing.
+        /// </summary>
+        /// <param name="token">Cancellation token to use for the run</param>
+        /// <returns></returns>
+        public async Task Init(CancellationToken token)
+        {
+            lock (_lock)
+            {
+                if (_initialized) return;
+                _initialized = true;
+            }
+            InitBase(token);
+            await TestConfig().ConfigureAwait(false);
+            await InitTasks().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Start the extractor and wait for it to finish.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        public async Task Start(CancellationToken token)
+        {
+            await Init(token).ConfigureAwait(false);
+            // TODO: Post startup message to integrations.
+
+            // Start monitoring the task scheduler and run sink.
+            AddMonitoredTask(TaskScheduler.Run(Source.Token), "TaskScheduler");
+            AddMonitoredTask(_sink.Run(token), ExtractorTaskResult.Unexpected, "Sink");
+
+            while (!token.IsCancellationRequested)
+            {
+                var toWaitFor = new List<Task>();
+                lock (_lock)
+                {
+                    _triggerEvent.Reset();
+                    var toRemove = new List<MonitoredTask>();
+                    foreach (var monitored in _monitoredTaskList)
+                    {
+                        if (!monitored.Task.IsCompleted) continue;
+
+                        if (!monitored.Task.IsFaulted && !monitored.Task.IsCanceled)
+                        {
+                            var result = monitored.Task.Result;
+                            if (result == ExtractorTaskResult.Unexpected && !token.IsCancellationRequested)
+                            {
+                                _logger.LogError("Internal task {Name} completed, but was not expected to stop, restarting extractor.", monitored.Name);
+                                Fatal($"Internal task {monitored.Name} completed, but was not expected to stop, restarting extractor.");
+                                return;
+                            }
+                        }
+                        else if (monitored.Task.IsFaulted)
+                        {
+                            var exc = monitored.Task.Exception;
+                            var flattenedExc = exc?.InnerException ?? exc;
+                            _logger.LogError(flattenedExc, "Internal task {Name} failed, restarting extractor: {Message}", monitored.Name, flattenedExc?.Message);
+                            Fatal($"Internal task {monitored.Name} failed, restarting extractor: {flattenedExc?.Message}", flattenedExc?.StackTrace?.ToString());
+                            return;
+                        }
+                        _logger.LogDebug("Internal task {Name} completed.", monitored.Name);
+                        toRemove.Add(monitored);
+                    }
+                    foreach (var rem in toRemove) _monitoredTaskList.Remove(rem);
+
+                    toWaitFor.AddRange(_monitoredTaskList.Select(mt => mt.Task));
+                }
+
+                toWaitFor.Add(CommonUtils.WaitAsync(_triggerEvent, Timeout.InfiniteTimeSpan, token));
+
+                await Task.WhenAny(toWaitFor).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Verify that the extractor is configured correctly.
+        /// 
+        /// Does nothing by default.
+        /// </summary>
+        /// <returns>Task</returns>
+        protected virtual Task TestConfig()
+        {
+            return Task.CompletedTask;
+        }
+
+
+        /// <inheritdoc />
+        public override ExtractorError NewError(ErrorLevel level, string description, string? details = null, DateTime? now = null)
+        {
+            return new ExtractorError(level, description, _sink, details, null, now);
+        }
+
+        /// <summary>
+        /// Dispose asynchronously, override this to clean up your resources
+        /// on shutdown.
+        /// </summary>
+        /// <returns></returns>
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            // First, shut down the task scheduler.
+            await TaskScheduler.CancelInnerAndWait(20000, this).ConfigureAwait(false);
+            // Next, flush any remaining task updates.
+            await _sink.Flush(CancellationToken.None).ConfigureAwait(false);
+            // Finally, cancel the outer token source.
+            Source?.Cancel();
+            Source?.Dispose();
+        }
+
+        /// <summary>
+        /// Dispose the extractor asynchronously.
+        /// </summary>
+        /// <returns></returns>
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await DisposeAsyncCore().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to dispose of extractor: {}", ex.Message);
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/ExtractorUtils/Unstable/BaseExtractor.cs
+++ b/ExtractorUtils/Unstable/BaseExtractor.cs
@@ -34,9 +34,8 @@ namespace Cognite.ExtractorUtils.Unstable
 
     /// <summary>
     /// Class wrapping a task being monitored by the extractor.
-    /// This is simply a way to run background tasks without
-    /// running them as actual extractor tasks reported to
-    /// integrations.
+    /// This is simply a way to run background tasks that
+    /// don't get reported to integrations.
     /// </summary>
     class MonitoredTask
     {
@@ -162,7 +161,7 @@ namespace Cognite.ExtractorUtils.Unstable
         /// <summary>
         /// Add a task that should be watched by the extractor.
         /// 
-        /// Use this for tasks that should not be reported to integrations,
+        /// Use this for tasks that will not be reported to integrations,
         /// but that you still want to monitor, so that the extractor can crash
         /// if they fail or exit unexpectedly.
         /// </summary>
@@ -212,7 +211,7 @@ namespace Cognite.ExtractorUtils.Unstable
         /// <summary>
         /// Add a monitored task that should be watched by the extractor.
         /// 
-        /// Use this for tasks that should not be reported to integrations,
+        /// Use this for tasks that will not be reported to integrations,
         /// but that you still want to monitor, so that the extractor can crash
         /// if they fail or exit unexpectedly.
         /// 

--- a/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
+++ b/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
@@ -48,7 +48,7 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// </summary>
         /// <param name="token">Cancellation token</param>
         /// <param name="interval">Interval, defaults to 30 seconds.</param>
-        public async Task Run(CancellationToken token, TimeSpan? interval = null)
+        public async Task RunPeriodicCheckin(CancellationToken token, TimeSpan? interval = null)
         {
             lock (_lock)
             {

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Cognite.Extractor.Common;
 using CogniteSdk.Alpha;
 
@@ -173,6 +175,21 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// <param name="update">Content of the task update.</param>
         /// <param name="timestamp">When the task started, defaults to current time.</param>
         void ReportTaskStart(string taskName, TaskUpdatePayload? update = null, DateTime? timestamp = null);
+
+        /// <summary>
+        /// Flush the sink, ensuring all errors and tasks are written.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        Task Flush(CancellationToken token);
+
+        /// <summary>
+        /// Run the sink, automatically flushing at regular intervals.
+        /// </summary>
+        /// <param name="token">Cancellation token.</param>
+        /// <param name="interval">Interval. If left out, uses an implementation-defined default.</param>
+        /// <returns></returns>
+        Task Run(CancellationToken token, TimeSpan? interval = null);
     }
 
     /// <summary>

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -189,7 +189,7 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// <param name="token">Cancellation token.</param>
         /// <param name="interval">Interval. If left out, uses an implementation-defined default.</param>
         /// <returns></returns>
-        Task Run(CancellationToken token, TimeSpan? interval = null);
+        Task RunPeriodicCheckin(CancellationToken token, TimeSpan? interval = null);
     }
 
     /// <summary>

--- a/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
+++ b/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Cognite.Extensions;
 using Cognite.Extractor.Common;
+using Microsoft.Extensions.Logging;
 
 namespace Cognite.ExtractorUtils.Unstable.Tasks
 {
@@ -245,15 +246,26 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         private object _lock = new object();
         private ManualResetEvent _evt = new ManualResetEvent(false);
 
+        private TaskCompletionSource<bool> _runMethodClosed = new TaskCompletionSource<bool>();
+
         private bool disposedValue;
+
+        /// <summary>
+        /// Task that terminates once the run method terminates.
+        /// </summary>
+        public Task CompletedTask => _runMethodClosed.Task;
+
+        private ILogger _logger;
 
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="sink">Sink for task updates.</param>
-        public ExtractorTaskScheduler(IIntegrationSink sink)
+        /// <param name="logger">Logger object.</param>
+        public ExtractorTaskScheduler(IIntegrationSink sink, ILogger<ExtractorTaskScheduler> logger)
         {
             _sink = sink;
+            _logger = logger;
         }
 
         /// <summary>
@@ -376,6 +388,8 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
 
         private bool _started;
 
+
+
         /// <summary>
         /// Run the scheduler.
         /// 
@@ -384,12 +398,41 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
         /// To re-run it after a crash, the scheduler must be re-initialized.
         /// </summary>
         /// <param name="token">Global cancellation token for stopping the entire scheduler.</param>
-        public async Task Run(CancellationToken token)
+        public async Task<ExtractorTaskResult> Run(CancellationToken token)
         {
             if (_started) throw new InvalidOperationException("Attempt to run scheduler multiple times");
             _started = true;
+
+            try
+            {
+                await RunInner(token).ConfigureAwait(false);
+                _runMethodClosed.TrySetResult(true);
+            }
+            catch (Exception ex)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    _runMethodClosed.TrySetResult(true);
+                }
+                else
+                {
+                    _runMethodClosed.TrySetException(ex);
+                }
+            }
+
+            bool isCancelled = _source?.Token.IsCancellationRequested ?? false;
+
+            return isCancelled ? ExtractorTaskResult.Expected : ExtractorTaskResult.Unexpected;
+        }
+
+
+        private async Task RunInner(CancellationToken token)
+        {
             _source = CancellationTokenSource.CreateLinkedTokenSource(token);
-            while (!_source.IsCancellationRequested)
+            // Waits for the outer token, not the internal source.
+            // This way we can cancel the task scheduler first, without
+            // canceling everything else.
+            while (!_source.Token.IsCancellationRequested)
             {
                 _evt.Reset();
                 var tickTime = DateTime.UtcNow;
@@ -405,6 +448,7 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
                         // If the task has finished, take steps to mark it as completed.
                         if (task.ActiveTask != null && task.ActiveTask.Task.IsCompleted)
                         {
+                            _logger.LogDebug("Finish run of task {Name}", task.Operation.Name);
                             task.FinishTask(tickTime);
                         }
 
@@ -415,6 +459,7 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
                         {
                             if (task.NextRun.Value <= tickTime)
                             {
+                                _logger.LogDebug("Start new run of task {Name}", task.Operation.Name);
                                 task.Run(tickTime, token);
                             }
                             else if (minNextRun == null || minNextRun > task.NextRun.Value)
@@ -445,8 +490,28 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
 
                 // Always wait for the event to trigger.
                 toAwait.Add(CommonUtils.WaitAsync(_evt, Timeout.InfiniteTimeSpan, _source.Token));
-
                 await Task.WhenAny(toAwait).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Cancel the running task, if it exists.
+        /// </summary>
+        public async Task CancelInnerAndWait(int timeoutms, BaseErrorReporter outerReporter)
+        {
+            if (!_started) return;
+            _source?.Cancel();
+            var waitTask = Task.Delay(timeoutms);
+            var completed = await Task.WhenAny(waitTask, CompletedTask).ConfigureAwait(false);
+            if (completed == waitTask)
+            {
+                _logger.LogWarning("Failed to shut down gracefully within timeout, continuing shutdown");
+                outerReporter?.Warning("Failed to shut down gracefully within timeout, continuing shutdown");
+            }
+
+            if (completed.Exception != null)
+            {
+                outerReporter?.Fatal($"Failed to shut down gracefully: {completed.Exception.Message}", completed.Exception.StackTrace?.ToString());
             }
         }
 

--- a/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
+++ b/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
@@ -513,8 +513,8 @@ namespace Cognite.ExtractorUtils.Unstable.Tasks
             var completed = await Task.WhenAny(waitTask, CompletedTask).ConfigureAwait(false);
             if (completed == waitTask)
             {
-                _logger.LogWarning("Failed to shut down gracefully within timeout, continuing shutdown");
-                outerReporter?.Warning("Failed to shut down gracefully within timeout, continuing shutdown");
+                _logger.LogWarning("Failed to shut down gracefully within timeout");
+                outerReporter?.Warning("Failed to shut down gracefully within timeout");
             }
 
             if (completed.Exception != null)


### PR DESCRIPTION
First take on a new base extractor class. Some more work goes into this in the next step, adding startup reporting and integrating things a bit more tightly, but this is a nice first draft that contains some of the core logic.

The base extractor has a few roles, currently:

 - It contains the config object, in the future it will also handle changes to config revision and restart.
 - It acts as an error reporter, for raw errors.
 - It manages "monitored tasks", which are essentially just C# Tasks. The idea is that if something fails in a background process, this needs to be properly reported to the extractor so that it can take appropriate action. Background tasks have a name, can be cancelled independently, and can be expected to end or not, so if a task ends without an error, the extractor can take appropriate action.
 - It also contains shutdown logic, which is highly customizable, since extractor implementations may want to shut components down in a specific order. In general, different parts of the process are supposed to be independently cancelled, so that graceful shutdown is possible.

As with the last iteration of the base extractor, it is intended to be used as a base class for user extractors.