### PR TITLE
Improve the checkin worker a bit, add a callback for config changes

### DIFF
--- a/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
@@ -218,6 +218,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
             await checkIn.Flush(source.Token);
             Assert.Equal(2, _checkInCallbacks.Count);
             Assert.Equal(2, _checkInCallbacks[1]);
+            Assert.Equal(1, _checkInCallbacks[0]);
         }
 
 

--- a/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
@@ -61,6 +61,8 @@ namespace ExtractorUtils.Test.Unit.Unstable
             };
         }
 
+        private List<int> _checkInCallbacks = new();
+
         private (ServiceProvider, CheckInWorker) GetCheckInWorker()
         {
             var config = GetConfig();
@@ -77,7 +79,13 @@ namespace ExtractorUtils.Test.Unit.Unstable
 
             var client = provider.GetRequiredService<Client>();
 
-            return (provider, new CheckInWorker(config.Integration, provider.GetRequiredService<ILogger<CheckInWorker>>(), client));
+            return (provider, new CheckInWorker(
+                config.Integration,
+                provider.GetRequiredService<ILogger<CheckInWorker>>(),
+                client,
+                _checkInCallbacks.Add,
+                0
+            ));
         }
 
         [Fact]
@@ -115,6 +123,8 @@ namespace ExtractorUtils.Test.Unit.Unstable
             await checkIn.Flush(source.Token);
             Assert.Equal(4, _checkInCount);
             Assert.Equal(2, errors.Count);
+            Assert.Single(_checkInCallbacks);
+            Assert.Equal(1, _checkInCallbacks[0]);
 
             // Report some task ends
             checkIn.ReportTaskEnd("task1", null, start.AddSeconds(2));
@@ -122,6 +132,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
             await checkIn.Flush(source.Token);
             Assert.Equal(5, _checkInCount);
             Assert.Equal(4, taskEvents.Count);
+            Assert.Single(_checkInCallbacks);
 
             source.Cancel();
             await TestUtils.RunWithTimeout(runTask, 5);
@@ -173,6 +184,40 @@ namespace ExtractorUtils.Test.Unit.Unstable
 
             source.Cancel();
             await TestUtils.RunWithTimeout(runTask, 5);
+        }
+
+        [Fact]
+        public async Task TestCheckInWorkerCallback()
+        {
+            var (provider, checkIn) = GetCheckInWorker();
+            using var p = provider;
+            using var source = new CancellationTokenSource();
+
+            // Check that this doesn't crash, and properly cancels out at the end.
+            var runTask = checkIn.RunPeriodicCheckin(source.Token, Timeout.InfiniteTimeSpan);
+            // First, we should very quickly report a checkin on the start of the run task...
+            await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
+
+            // Flush, without getting a new config revision.
+            await checkIn.Flush(source.Token);
+            Assert.Empty(_checkInCallbacks);
+
+            // Set a new revision and flush again.
+            _lastConfigRevision = 1;
+            await checkIn.Flush(source.Token);
+            Assert.Single(_checkInCallbacks);
+            Assert.Equal(1, _checkInCallbacks[0]);
+
+            // Flush without changes
+            await checkIn.Flush(source.Token);
+            Assert.Single(_checkInCallbacks);
+            Assert.Equal(1, _checkInCallbacks[0]);
+
+            // Flush with a new revision
+            _lastConfigRevision = 2;
+            await checkIn.Flush(source.Token);
+            Assert.Equal(2, _checkInCallbacks.Count);
+            Assert.Equal(2, _checkInCallbacks[1]);
         }
 
 

--- a/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
+++ b/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
@@ -258,21 +258,18 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
 
         private void HandleCheckInResponse(CheckInResponse response)
         {
-            if (_activeRevision != null
-                && response.LastConfigRevision != _activeRevision
-                && response.LastConfigRevision != null)
+            if (response.LastConfigRevision != _activeRevision && response.LastConfigRevision != null)
             {
-                if (_onRevisionChanged != null)
+                if (_activeRevision != null && _onRevisionChanged != null)
                 {
                     _logger.LogInformation("Remote config revision changed {From} -> {To}", _activeRevision, response.LastConfigRevision);
                     _onRevisionChanged(response.LastConfigRevision.Value);
                 }
-                else
+                else if (_activeRevision != null)
                 {
                     _logger.LogInformation(
-                        "Remote config revision changed {From} -> {To}. The extractor is currently using local configuration and will not restart.",
+                        "Remote config revision changed {From} -> {To}. The extractor is currently using local configuration and will need to be manually restarted and configured to use remote config for the new config to take effect.",
                         _activeRevision, response.LastConfigRevision);
-
                 }
                 _activeRevision = response.LastConfigRevision.Value;
             }


### PR DESCRIPTION
This is necessary step, making the checkin worker capable of calling some callback to inform the runtime and/or extractor (not sure yet) that a new config revision has been produced, and that the extractor should restart.

It will be up to the outer loop to decide whether the config changes are significant enough to warrant a change (if we decide to go that way).

I also improved the checkin worker a bit in general, making it a bit more resilient to cancellation.

It's quite important that errors aren't lost when the extractor shuts down, so we need to make sure that any errors that failed to write or weren't written are kept for a future checkin.