### PR TITLE
Report startup

### DIFF
--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.68.0" />
-    <PackageReference Include="CogniteSdk" Version="4.13.3" />
+    <PackageReference Include="CogniteSdk" Version="4.13.4" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />

--- a/ExtractorUtils.Test/unit/Unstable/BaseExtractorTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/BaseExtractorTest.cs
@@ -9,6 +9,7 @@ using Cognite.Extractor.Utils;
 using Cognite.Extractor.Utils.Unstable;
 using Cognite.Extractor.Utils.Unstable.Configuration;
 using Cognite.Extractor.Utils.Unstable.Tasks;
+using CogniteSdk.Alpha;
 using ExtractorUtils.Test.unit.Unstable;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -46,6 +47,15 @@ namespace ExtractorUtils.Test.Unit.Unstable
         {
             InitAction?.Invoke(TaskScheduler);
             return Task.CompletedTask;
+        }
+
+        protected override ExtractorId GetExtractorVersion()
+        {
+            return new ExtractorId
+            {
+                Version = "1.0.0",
+                ExternalId = "my-extractor"
+            };
         }
     }
 
@@ -92,6 +102,15 @@ namespace ExtractorUtils.Test.Unit.Unstable
             Assert.Single(sink.TaskStart);
             Assert.Single(sink.TaskEnd);
             Assert.Empty(sink.Errors);
+            Assert.Single(sink.StartupRequests);
+
+            var req = sink.StartupRequests[0];
+            Assert.Single(req.Tasks);
+            Assert.Equal("task1", req.Tasks.ElementAt(0).Name);
+            Assert.Equal("My task", req.Tasks.ElementAt(0).Description);
+            Assert.Equal(TaskType.batch, req.Tasks.ElementAt(0).Type);
+            Assert.Equal("my-extractor", req.Extractor.ExternalId);
+            Assert.Equal("1.0.0", req.Extractor.Version);
         }
 
         [Fact]

--- a/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
@@ -97,16 +97,16 @@ namespace ExtractorUtils.Test.Unit.Unstable
             using var p = provider;
             using var source = new CancellationTokenSource();
             // Check that this doesn't crash, and properly cancels out at the end.
-            var runTask = checkIn.RunPeriodicCheckin(source.Token, new StartupRequest(), Timeout.InfiniteTimeSpan);
-            // First, we should very quickly report a checkin on the start of the run task...
+            var runTask = checkIn.RunPeriodicCheckIn(source.Token, new StartupRequest(), Timeout.InfiniteTimeSpan);
+            // First, we should very quickly report a check-in on the start of the run task...
             await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
 
-            // Report an empty checkin.
+            // Report an empty check-in.
             await checkIn.Flush(source.Token);
             Assert.Equal(2, _checkInCount);
 
             var start = DateTime.UtcNow;
-            // Report a checkin with some task starts
+            // Report a check-in with some task starts
             checkIn.ReportTaskStart("task1", null, start);
             checkIn.ReportTaskStart("task2", null, start);
             await checkIn.Flush(source.Token);
@@ -152,8 +152,8 @@ namespace ExtractorUtils.Test.Unit.Unstable
             using var source = new CancellationTokenSource();
 
             // Check that this doesn't crash, and properly cancels out at the end.
-            var runTask = checkIn.RunPeriodicCheckin(source.Token, new StartupRequest(), Timeout.InfiniteTimeSpan);
-            // First, we should very quickly report a checkin on the start of the run task...
+            var runTask = checkIn.RunPeriodicCheckIn(source.Token, new StartupRequest(), Timeout.InfiniteTimeSpan);
+            // First, we should very quickly report a check-in on the start of the run task...
             await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
 
             // Lots of task updates.
@@ -200,8 +200,8 @@ namespace ExtractorUtils.Test.Unit.Unstable
             using var source = new CancellationTokenSource();
 
             // Check that this doesn't crash, and properly cancels out at the end.
-            var runTask = checkIn.RunPeriodicCheckin(source.Token, new StartupRequest(), Timeout.InfiniteTimeSpan);
-            // First, we should very quickly report a checkin on the start of the run task...
+            var runTask = checkIn.RunPeriodicCheckIn(source.Token, new StartupRequest(), Timeout.InfiniteTimeSpan);
+            // First, we should very quickly report a check-in on the start of the run task...
             await TestUtils.WaitForCondition(() => _checkInCount == 1, 5);
 
             // Flush, without getting a new config revision.

--- a/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
@@ -44,7 +44,7 @@ namespace ExtractorUtils.Test.unit.Unstable
             TaskStart.Add((taskName, timestamp ?? DateTime.UtcNow));
         }
 
-        public async Task RunPeriodicCheckin(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null)
+        public async Task RunPeriodicCheckIn(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null)
         {
             StartupRequests.Add(startupPayload);
             while (!token.IsCancellationRequested) await Task.Delay(100000, token);

--- a/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
@@ -17,6 +17,8 @@ namespace ExtractorUtils.Test.unit.Unstable
         public List<(string, DateTime)> TaskStart { get; } = new();
         public List<(string, DateTime)> TaskEnd { get; } = new();
 
+        public List<StartupRequest> StartupRequests { get; } = new();
+
         public Task Flush(CancellationToken token)
         {
             return Task.CompletedTask;
@@ -42,8 +44,9 @@ namespace ExtractorUtils.Test.unit.Unstable
             TaskStart.Add((taskName, timestamp ?? DateTime.UtcNow));
         }
 
-        public async Task RunPeriodicCheckin(CancellationToken token, TimeSpan? interval = null)
+        public async Task RunPeriodicCheckin(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null)
         {
+            StartupRequests.Add(startupPayload);
             while (!token.IsCancellationRequested) await Task.Delay(100000, token);
         }
     }
@@ -59,6 +62,11 @@ namespace ExtractorUtils.Test.unit.Unstable
         public override string Name { get; }
 
         private Func<BaseErrorReporter, CancellationToken, Task<TaskUpdatePayload>> _func;
+
+        public override TaskMetadata Metadata { get; } = new TaskMetadata(TaskType.batch)
+        {
+            Description = "My task"
+        };
 
         public RunQuickTask(string name, Func<BaseErrorReporter, CancellationToken, Task<TaskUpdatePayload>> func)
         {

--- a/ExtractorUtils/Unstable/BaseExtractor.cs
+++ b/ExtractorUtils/Unstable/BaseExtractor.cs
@@ -299,7 +299,7 @@ namespace Cognite.Extractor.Utils.Unstable
 
             // Start monitoring the task scheduler and run sink.
             AddMonitoredTask(TaskScheduler.Run, "TaskScheduler");
-            AddMonitoredTask(t => _sink.RunPeriodicCheckin(t, GetStartupRequest()), ExtractorTaskResult.Unexpected, "CheckInWorker");
+            AddMonitoredTask(t => _sink.RunPeriodicCheckIn(t, GetStartupRequest()), ExtractorTaskResult.Unexpected, "CheckInWorker");
 
             while (!Source.IsCancellationRequested)
             {

--- a/ExtractorUtils/Unstable/BaseExtractor.cs
+++ b/ExtractorUtils/Unstable/BaseExtractor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Cognite.Extractor.Common;
 using Cognite.Extractor.Utils.Unstable.Configuration;
 using Cognite.Extractor.Utils.Unstable.Tasks;
+using CogniteSdk;
 using CogniteSdk.Alpha;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -159,6 +160,12 @@ namespace Cognite.Extractor.Utils.Unstable
         /// <returns></returns>
         protected abstract Task InitTasks();
 
+        /// <summary>
+        /// Return the version of the active extractor.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract ExtractorId GetExtractorVersion();
+
         private void InitBase(CancellationToken token)
         {
             if (Source != null) throw new InvalidOperationException("Extractor already started");
@@ -268,6 +275,18 @@ namespace Cognite.Extractor.Utils.Unstable
             await InitTasks().ConfigureAwait(false);
         }
 
+        private StartupRequest GetStartupRequest()
+        {
+            return new StartupRequest()
+            {
+                ActiveConfigRevision = ConfigRevision.HasValue
+                    ? StringOrInt.Create(ConfigRevision.Value)
+                    : StringOrInt.Create("local"),
+                Tasks = TaskScheduler.GetRegisteredTasks().ToList(),
+                Extractor = GetExtractorVersion(),
+            };
+        }
+
         /// <summary>
         /// Start the extractor and wait for it to finish.
         /// </summary>
@@ -280,7 +299,7 @@ namespace Cognite.Extractor.Utils.Unstable
 
             // Start monitoring the task scheduler and run sink.
             AddMonitoredTask(TaskScheduler.Run, "TaskScheduler");
-            AddMonitoredTask(t => _sink.RunPeriodicCheckin(t), ExtractorTaskResult.Unexpected, "CheckInWorker");
+            AddMonitoredTask(t => _sink.RunPeriodicCheckin(t, GetStartupRequest()), ExtractorTaskResult.Unexpected, "CheckInWorker");
 
             while (!Source.IsCancellationRequested)
             {

--- a/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
+++ b/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
@@ -49,8 +49,8 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// config revision since the last checkin. Null indiciates that the extractor is running local config,
         /// and should not restart based on changes to remote config.</param>
         /// <param name="retryStartup">Whether to retry the startup request if it fails,
-        /// beyond normal retries. If this is `true`, the checkin worker will retry startup requests forever,
-        /// or until they succeed.</param>
+        /// beyond normal retries. If this is `true`, the check-in worker will retry startup requests indefinitely,
+        /// instead of raising an exception.</param>
         public CheckInWorker(
             string integrationId,
             ILogger logger,
@@ -94,7 +94,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
             // before the startup request has been sent.
             // With this, calls to flush will wait until the startup request has been sent,
             // or startup fails.
-            // This prevents unfortunate behavior if we recover connection to CDF, then immediately shut down.
+            // This keeps us from reporting events before the startup, in case the extractor is started offline.
             // In this case, we would like to potentially report a startup and anything that has happened
             // while the connection to CDF was down.
             try

--- a/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
+++ b/ExtractorUtils/Unstable/Tasks/CheckInWorker.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace Cognite.Extractor.Utils.Unstable.Tasks
 {
     /// <summary>
-    /// Worker for submitting periodic checkins to the integrations API.
+    /// Worker for submitting periodic check-ins to the integrations API.
     /// </summary>
     public class CheckInWorker : IIntegrationSink
     {
@@ -75,7 +75,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// </summary>
         /// <param name="token">Cancellation token</param>
         /// <param name="startupPayload">Payload to send to the startup endpoint before beginning to
-        /// report periodic checkins..</param>
+        /// report periodic check-ins..</param>
         /// <param name="interval">Interval, defaults to 30 seconds.</param>
         public async Task RunPeriodicCheckIn(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null)
         {
@@ -90,7 +90,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
             // Make sure the external ID in the startup payload matches the external ID of the target integration.
             startupPayload.ExternalId = _integrationId;
 
-            // Hold the flush lock while reporting startup, to ensure that we don't start reporting checkins
+            // Hold the flush lock while reporting startup, to ensure that we don't start reporting check-ins
             // before the startup request has been sent.
             // With this, calls to flush will wait until the startup request has been sent,
             // or startup fails.

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -188,7 +188,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// </summary>
         /// <param name="token">Cancellation token.</param>
         /// <param name="startupPayload">Payload to send to the startup endpoint before beginning to
-        /// report periodic checkins..</param>
+        /// report periodic checkins.</param>
         /// <param name="interval">Interval. If left out, uses an implementation-defined default.</param>
         /// <returns></returns>
         Task RunPeriodicCheckin(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null);

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -191,7 +191,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// report periodic checkins.</param>
         /// <param name="interval">Interval. If left out, uses an implementation-defined default.</param>
         /// <returns></returns>
-        Task RunPeriodicCheckin(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null);
+        Task RunPeriodicCheckIn(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null);
     }
 
     /// <summary>

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -188,7 +188,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// </summary>
         /// <param name="token">Cancellation token.</param>
         /// <param name="startupPayload">Payload to send to the startup endpoint before beginning to
-        /// report periodic checkins.</param>
+        /// report periodic check-ins.</param>
         /// <param name="interval">Interval. If left out, uses an implementation-defined default.</param>
         /// <returns></returns>
         Task RunPeriodicCheckIn(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null);

--- a/ExtractorUtils/Unstable/Tasks/Errors.cs
+++ b/ExtractorUtils/Unstable/Tasks/Errors.cs
@@ -187,9 +187,11 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// Run the sink, automatically flushing at regular intervals.
         /// </summary>
         /// <param name="token">Cancellation token.</param>
+        /// <param name="startupPayload">Payload to send to the startup endpoint before beginning to
+        /// report periodic checkins..</param>
         /// <param name="interval">Interval. If left out, uses an implementation-defined default.</param>
         /// <returns></returns>
-        Task RunPeriodicCheckin(CancellationToken token, TimeSpan? interval = null);
+        Task RunPeriodicCheckin(CancellationToken token, StartupRequest startupPayload, TimeSpan? interval = null);
     }
 
     /// <summary>

--- a/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
+++ b/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Cognite.Extensions;
 using Cognite.Extractor.Common;
+using CogniteSdk.Alpha;
 using Microsoft.Extensions.Logging;
 
 namespace Cognite.Extractor.Utils.Unstable.Tasks
@@ -66,6 +67,11 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// Should be null if the task only runs manually or on startup.
         /// </summary>
         public virtual ITimeSpanProvider? Schedule { get; }
+
+        /// <summary>
+        /// Provide metadata about the task, reported to integration during startup.
+        /// </summary>
+        public abstract TaskMetadata Metadata { get; }
     }
 
     internal sealed class RunningTaskInfo : IDisposable
@@ -382,6 +388,27 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
                 if (exc != null)
                 {
                     ExceptionDispatchInfo.Capture(exc).Throw();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get a list of registered tasks, used for reporting startup.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<IntegrationTask> GetRegisteredTasks()
+        {
+            lock (_lock)
+            {
+                foreach (var task in _tasks.Values)
+                {
+                    yield return new IntegrationTask
+                    {
+                        Name = task.Operation.Name,
+                        Description = task.Operation.Metadata.Description,
+                        Type = task.Operation.Metadata.Type,
+                        Action = task.Operation.Metadata.Action,
+                    };
                 }
             }
         }

--- a/ExtractorUtils/Unstable/Tasks/Task.cs
+++ b/ExtractorUtils/Unstable/Tasks/Task.cs
@@ -25,6 +25,34 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
     }
 
     /// <summary>
+    /// Task metadata object.
+    /// </summary>
+    public class TaskMetadata
+    {
+        /// <summary>
+        /// Type of task.
+        /// </summary>
+        public TaskType Type { get; set; }
+        /// <summary>
+        /// Whether the task can be triggered by an action or not.
+        /// </summary>
+        public bool Action { get; set; }
+        /// <summary>
+        /// Task description.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="type">Task type.</param>
+        public TaskMetadata(TaskType type)
+        {
+            Type = type;
+        }
+    }
+
+    /// <summary>
     /// Type handling reporting of events related to a single task.
     /// </summary>
     public class TaskReporter : BaseErrorReporter

--- a/ExtractorUtils/Unstable/Tasks/Task.cs
+++ b/ExtractorUtils/Unstable/Tasks/Task.cs
@@ -32,7 +32,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// <summary>
         /// Type of task.
         /// </summary>
-        public TaskType Type { get; set; }
+        public TaskType Type { get; private set; }
         /// <summary>
         /// Whether the task can be triggered by an action or not.
         /// </summary>


### PR DESCRIPTION
Final part of startup reporting. This ensures that we actually send the startup request before we report _any_ checkins, thus avoiding inconsistent state in CDF, even if the extractor runs offline for some time before being able to report startup.

The ability to run offline is opt-in, so the checkin worker can be configured to crash if we cannot connect to CDF.