### PR TITLE
Only auto-update renovate PRs if they are conflicting with master

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
This should help avoid noise and make it possible to actually get these PRs through risk review.