### PR TITLE
Avoid upserting spaces unnecessarily in tests

### DIFF
--- a/ExtractorUtils.Test/CDFTester.cs
+++ b/ExtractorUtils.Test/CDFTester.cs
@@ -66,6 +66,7 @@ namespace ExtractorUtils.Test
             }
 
             await DestinationWithIDM.CogniteClient.DataModels.UpsertSpaces(new List<SpaceCreate>() { new() { Space = _spaceId } });
+            _spaceUpserted = true;
 
             return _spaceId;
         }


### PR DESCRIPTION
This was causing schema lock conflicts and failing the tests. Instead just get the space ID when needed.