### PR TITLE
Align connection config with python utils

### DIFF
--- a/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/CheckInWorkerTests.cs
@@ -49,7 +49,10 @@ namespace ExtractorUtils.Test.Unit.Unstable
             {
                 Project = "project",
                 BaseUrl = "https://greenfield.cognitedata.com",
-                Integration = "test-integration",
+                Integration = new IntegrationConfig
+                {
+                    ExternalId = "test-integration"
+                },
                 Authentication = new ClientCredentialsConfig
                 {
                     ClientId = "someId",
@@ -82,7 +85,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
             var client = provider.GetRequiredService<Client>();
 
             return (provider, new CheckInWorker(
-                config.Integration,
+                config.Integration.ExternalId,
                 provider.GetRequiredService<ILogger<CheckInWorker>>(),
                 client,
                 _checkInCallbacks.Add,

--- a/ExtractorUtils.Test/unit/Unstable/ConnectionConfigTests.cs
+++ b/ExtractorUtils.Test/unit/Unstable/ConnectionConfigTests.cs
@@ -41,7 +41,10 @@ namespace ExtractorUtils.Test.Unit.Unstable
             {
                 Project = "project",
                 BaseUrl = "https://greenfield.cognitedata.com",
-                Integration = "test-integration",
+                Integration = new IntegrationConfig
+                {
+                    ExternalId = "test-integration"
+                },
                 Authentication = new ClientCredentialsConfig
                 {
                     ClientId = "someId",

--- a/ExtractorUtils.Test/unit/Unstable/RuntimeTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/RuntimeTest.cs
@@ -41,7 +41,8 @@ namespace ExtractorUtils.Test.unit.Unstable
             return @"
 project: project
 base-url: https://api.cognitedata.com
-integration: test-integration
+integration:
+    external-id: test-integration
 authentication:
   type: client-credentials
   client-id: someId
@@ -346,7 +347,10 @@ authentication:
             {
                 Project = "project",
                 BaseUrl = "https://greenfield.cognitedata.com",
-                Integration = "test-integration",
+                Integration = new IntegrationConfig
+                {
+                    ExternalId = "test-integration"
+                },
                 Authentication = new ClientCredentialsConfig
                 {
                     ClientId = "someId",

--- a/ExtractorUtils/Unstable/Runtime/Builder.cs
+++ b/ExtractorUtils/Unstable/Runtime/Builder.cs
@@ -242,7 +242,7 @@ namespace Cognite.Extractor.Utils.Unstable.Runtime
                     throw new ConfigurationException("Cannot use remote config without a connection config.");
                 }
 
-                if (connectionConfig.Integration == null)
+                if (connectionConfig.Integration?.ExternalId == null)
                 {
                     throw new ConfigurationException("Cannot use remote config without an integration.");
                 }
@@ -253,7 +253,7 @@ namespace Cognite.Extractor.Utils.Unstable.Runtime
                 var provider = services.BuildServiceProvider();
 
 
-                var configSource = new RemoteConfigSource<TConfig>(provider.GetRequiredService<Client>(), StartupLogger, connectionConfig.Integration, ConfigPath, BufferRemoteConfig);
+                var configSource = new RemoteConfigSource<TConfig>(provider.GetRequiredService<Client>(), StartupLogger, connectionConfig.Integration.ExternalId, ConfigPath, BufferRemoteConfig);
                 return configSource;
             }
         }

--- a/ExtractorUtils/Unstable/Runtime/Runtime.cs
+++ b/ExtractorUtils/Unstable/Runtime/Runtime.cs
@@ -210,7 +210,7 @@ namespace Cognite.Extractor.Utils.Unstable.Runtime
                 services.Add(_params.ExternalServices);
             }
 
-            var bootstrapErrorReporter = new BootstrapErrorReporter(_setupServiceProvider.GetService<Client>(), _connectionConfig?.Integration, _activeLogger);
+            var bootstrapErrorReporter = new BootstrapErrorReporter(_setupServiceProvider.GetService<Client>(), _connectionConfig?.Integration?.ExternalId, _activeLogger);
 
             try
             {
@@ -283,11 +283,11 @@ namespace Cognite.Extractor.Utils.Unstable.Runtime
             }
 
             // Register a live integration sink that the extractor will use for check-ins.
-            if (_connectionConfig?.Integration != null)
+            if (_connectionConfig?.Integration?.ExternalId != null)
             {
                 services.AddSingleton<IIntegrationSink>(provider =>
                     new CheckInWorker(
-                        _connectionConfig.Integration,
+                        _connectionConfig.Integration.ExternalId,
                         provider.GetRequiredService<ILogger<CheckInWorker>>(),
                         provider.GetRequiredService<Client>(),
                         (rev) => _revisionChangedEvent.Set(),


### PR DESCRIPTION
This is discussed in the config design doc. Move things around a bit to better align with the layout we agreed on for python utils.

This removes the SDK logging and makes it enabled by default on debug level, only in the unstable module for now.