### PR TITLE
Unstable fixes

### DIFF
--- a/ExtractorUtils/Unstable/BaseExtractor.cs
+++ b/ExtractorUtils/Unstable/BaseExtractor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Cognite.Extensions;
 using Cognite.Extractor.Common;
 using Cognite.Extractor.Utils.Unstable.Configuration;
 using Cognite.Extractor.Utils.Unstable.Tasks;
@@ -282,13 +283,15 @@ namespace Cognite.Extractor.Utils.Unstable
 
         private StartupRequest GetStartupRequest()
         {
+            var version = GetExtractorVersion();
+            version.Version = version.Version?.Truncate(32);
             return new StartupRequest()
             {
                 ActiveConfigRevision = ConfigRevision.HasValue
                     ? StringOrInt.Create(ConfigRevision.Value)
                     : StringOrInt.Create("local"),
                 Tasks = TaskScheduler.GetRegisteredTasks().ToList(),
-                Extractor = GetExtractorVersion(),
+                Extractor = version,
                 // StartTime is not null here, as this is called after Init.
                 Timestamp = CogniteTime.ToUnixTimeMilliseconds(StartTime!.Value),
             };

--- a/ExtractorUtils/Unstable/Runtime/Builder.cs
+++ b/ExtractorUtils/Unstable/Runtime/Builder.cs
@@ -317,7 +317,7 @@ namespace Cognite.Extractor.Utils.Unstable.Runtime
             }
 
             Console.CancelKeyPress += CancelKeyPressHandler;
-            var (configSource, connectionConfig) = await InitConfigSource(token).ConfigureAwait(false);
+            var (configSource, connectionConfig) = await InitConfigSource(source.Token).ConfigureAwait(false);
 
             return new ExtractorRuntime<TConfig, TExtractor>(this, configSource, connectionConfig, source);
         }

--- a/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
+++ b/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
@@ -125,7 +125,17 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
 
             if (Operation.Schedule != null)
             {
-                NextRun = now + Operation.Schedule.Value;
+                var value = Operation.Schedule.Value;
+                if (value == Timeout.InfiniteTimeSpan)
+                {
+                    // If the schedule is infinite, we should not set a next run time...
+                    // It's unfortunate that .NET has standardized on this weird InfiniteTimeSpan value, which is just -1 ms.
+                    NextRun = null;
+                }
+                else
+                {
+                    NextRun = now + value;
+                }
             }
             else
             {


### PR DESCRIPTION
Four minor fixes to the unstable module:

 - Treat InfiniteTimeSpan as infinite when scheduling tasks.
 - Pass the correct cancellation token to `InitConfigSource`, this was causing the extractor to hang if you tried to cancel it while it was failing due to missing connection config or the like.
 - Truncate extractor version. While extractor versions aren't longer than 32 characters, for local development or dev builds they can sometimes include revision info. The limit on the API is 32 chars.
 - Properly handle task scheduler cancellation. When the scheduler shuts down we do want to report that tasks have ended. I also changed it so we report a warning here, not a fatal failure, since that seems a bit strong. We should somehow report that the task didn't properly shut down, however.

I have a pair of larger fixes as well, that will come in separate PRs.