### PR TITLE
Use periodic scheduler in unstable base extractor

### DIFF
--- a/Cognite.Common/CommonUtils.cs
+++ b/Cognite.Common/CommonUtils.cs
@@ -145,5 +145,23 @@ namespace Cognite.Extractor.Common
             }, TaskScheduler.Current);
             return task;
         }
+
+        /// <summary>
+        /// Simplify an aggregate exception, flattening it and returning the inner exception
+        /// if it only contains one.
+        /// </summary>
+        /// <param name="ex">Exception to simplify.</param>
+        /// <returns>Simplified exception, or the original exception if it couldn't be simplified.</returns>
+        public static Exception SimplifyException(Exception ex)
+        {
+            if (ex is AggregateException aex)
+            {
+                var flat = aex.Flatten();
+                if (flat.InnerExceptions.Count == 1) return SimplifyException(flat.InnerExceptions[0]);
+                return flat;
+            }
+            return ex;
+        }
+
     }
 }

--- a/Cognite.Common/PeriodicScheduler.cs
+++ b/Cognite.Common/PeriodicScheduler.cs
@@ -347,6 +347,8 @@ namespace Cognite.Extractor.Common
         /// <summary>
         /// Same as calling ExitAndWaitForTermination on all tasks.
         /// </summary>
+        /// <param name="timeoutMs">Timeout in milliseconds</param>
+        /// <param name="cancel">True to cancel running tasks, false to just signal them to exit once they are done</param>
         /// <returns>Task which completes once all tasks are done</returns>
         public async Task ExitAllAndWait(int timeoutMs = 0, bool cancel = false)
         {

--- a/Cognite.Testing/TestUtils.cs
+++ b/Cognite.Testing/TestUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Cognite.Extractor.Common;
 using Xunit;
 using Xunit.Sdk;
 
@@ -132,6 +133,8 @@ namespace Cognite.Extractor.Testing
         /// <summary>
         /// Wait for task to complete or <paramref name="seconds"/>.
         /// Throws an exception if the task did not complete in time.
+        ///
+        /// Will re-throw any exception from the task, after simplifying it if it is an AggregateException.
         /// </summary>
         /// <param name="task">Task to wait for.</param>
         /// <param name="seconds"></param>
@@ -141,6 +144,12 @@ namespace Cognite.Extractor.Testing
             if (task == null) throw new ArgumentNullException(nameof(task));
             await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(seconds))).ConfigureAwait(false);
             Assert.True(task.IsCompleted, "Task did not complete in time");
+            if (task.IsFaulted)
+            {
+                // Rethrow exception preserving stack trace
+                var exc = CommonUtils.SimplifyException(task.Exception!);
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exc).Throw();
+            }
         }
 
         /// <summary>

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -366,7 +366,7 @@ namespace ExtractorUtils.Test.Unit
                 throw new CogniteUtilsException();
             });
 
-            var ex = await Assert.ThrowsAsync<AggregateException>(async () => await loopTask);
+            var ex = await Assert.ThrowsAsync<SchedulerException>(async () => await loopTask);
             Assert.IsType<CogniteUtilsException>(ex.InnerException);
 
             source.Cancel();

--- a/ExtractorUtils.Test/unit/Unstable/BaseExtractorTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/BaseExtractorTest.cs
@@ -42,7 +42,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
             Sink = sink;
         }
 
-        public void AddMonitoredTaskPub(Func<CancellationToken, Task> task, ExtractorTaskResult staticResult, string name)
+        public void AddMonitoredTaskPub(Func<CancellationToken, Task> task, SchedulerTaskResult staticResult, string name)
         {
             AddMonitoredTask(task, staticResult, name);
         }
@@ -156,11 +156,11 @@ namespace ExtractorUtils.Test.Unit.Unstable
             {
                 await Task.Delay(100, t);
                 throw new Exception("Monitored error");
-            }, ExtractorTaskResult.Unexpected, "task1");
+            }, SchedulerTaskResult.Unexpected, "task1");
             var delayTask = Task.Delay(2000);
             Assert.NotEqual(delayTask, await Task.WhenAny(runTask, delayTask));
             Assert.Equal(2, sink.Errors.Count);
-            Assert.Equal("Internal task task1 failed, restarting extractor: Monitored error", sink.Errors[0].Description);
+            Assert.Equal("Task task1 failed: Monitored error", sink.Errors[0].Description);
         }
 
         [Fact]
@@ -171,11 +171,11 @@ namespace ExtractorUtils.Test.Unit.Unstable
             ext.AddMonitoredTaskPub(async t =>
             {
                 await Task.Delay(100, t);
-            }, ExtractorTaskResult.Unexpected, "task1");
+            }, SchedulerTaskResult.Unexpected, "task1");
             var delayTask = Task.Delay(2000);
             Assert.NotEqual(delayTask, await Task.WhenAny(runTask, delayTask));
             Assert.Equal(2, sink.Errors.Count);
-            Assert.Equal("Internal task task1 completed, but was not expected to stop, restarting extractor.", sink.Errors[0].Description);
+            Assert.Equal("Task task1 completed, but was not expected to stop.", sink.Errors[0].Description);
         }
 
         [Fact]
@@ -189,7 +189,7 @@ namespace ExtractorUtils.Test.Unit.Unstable
                 {
                     await Task.Delay(100, t);
                 }
-            }, ExtractorTaskResult.Unexpected, "task1");
+            }, SchedulerTaskResult.Unexpected, "task1");
             var delayTask = Task.Delay(2000);
             Assert.NotEqual(delayTask, await Task.WhenAny(ext.CancelMonitoredTaskAndWaitPub("task1"), delayTask));
             Assert.NotEqual(delayTask, await Task.WhenAny(ext.Shutdown(), delayTask));

--- a/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
+++ b/ExtractorUtils/Unstable/Tasks/ExtractorTaskScheduler.cs
@@ -435,7 +435,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
         /// To re-run it after a crash, the scheduler must be re-initialized.
         /// </summary>
         /// <param name="token">Global cancellation token for stopping the entire scheduler.</param>
-        public async Task<ExtractorTaskResult> Run(CancellationToken token)
+        public async Task<SchedulerTaskResult> Run(CancellationToken token)
         {
             if (_started) throw new InvalidOperationException("Attempt to run scheduler multiple times");
             _started = true;
@@ -460,7 +460,7 @@ namespace Cognite.Extractor.Utils.Unstable.Tasks
 
             bool isCancelled = _source?.Token.IsCancellationRequested ?? false;
 
-            return isCancelled ? ExtractorTaskResult.Expected : ExtractorTaskResult.Unexpected;
+            return isCancelled ? SchedulerTaskResult.Expected : SchedulerTaskResult.Unexpected;
         }
 
 


### PR DESCRIPTION
Required some refactoring and new features in the scheduler, but I think the result is pretty good. There's no real reason to have _two_ of these, and this way it's possible to use the "periodic" features on the periodic scheduler directly from extractors, which we do a fair bit, simplifying migration.