### PR TITLE
Use CdfMocker in raw tests

### DIFF
--- a/Cognite.Testing/Mock/CdfMock.cs
+++ b/Cognite.Testing/Mock/CdfMock.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Cognite.Extractor.Utils;
 using CogniteSdk;
 using Microsoft.Extensions.DependencyInjection;
@@ -95,6 +96,20 @@ namespace Cognite.Extractor.Testing.Mock
         {
             var error = new CogniteError((int)statusCode, message);
             return CreateJsonResponse(new CogniteErrorWrapper(error), statusCode);
+        }
+
+        /// <summary>
+        /// Parses the query string of the request URI into a dictionary.
+        /// </summary>
+        public Dictionary<string, string> ParseQuery()
+        {
+            var query = HttpUtility.ParseQueryString(RawRequest.RequestUri.Query);
+            var result = new Dictionary<string, string>();
+            foreach (var key in query.AllKeys)
+            {
+                result[key] = query[key];
+            }
+            return result;
         }
     }
 

--- a/Cognite.Testing/Mock/Matchers.cs
+++ b/Cognite.Testing/Mock/Matchers.cs
@@ -56,7 +56,15 @@ namespace Cognite.Extractor.Testing.Mock
         /// </summary>
         public void AssertMatches()
         {
-            Assert.True(ExpectedRequestCount.Validate(RequestCount), $"Wrong number of requests for path '{Name}': got {RequestCount}, expected {ExpectedRequestCount}");
+            AssertMatches(ExpectedRequestCount);
+        }
+
+        /// <summary>
+        /// Assert that this has been called the number of times given.
+        /// </summary>
+        public void AssertMatches(Times times)
+        {
+            Assert.True(times.Validate(RequestCount), $"Wrong number of requests for path '{Name}': got {RequestCount}, expected {times}");
         }
 
         /// <summary>

--- a/Cognite.Testing/Mock/Raw.cs
+++ b/Cognite.Testing/Mock/Raw.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -8,9 +10,75 @@ using System.Threading.Tasks;
 using Cognite.Extractor.Common;
 using CogniteSdk;
 using Moq;
+using Oryx.Cognite;
 
 namespace Cognite.Extractor.Testing.Mock
 {
+    /// <summary>
+    /// A wrapper around a mocked raw table, to simplify access to typed rows.
+    /// </summary>
+    public class RawTable
+    {
+        /// <summary>
+        /// Raw reference to the rows in the table.
+        /// </summary>
+        public Dictionary<string, RawRow<JsonNode>> Rows { get; } = new Dictionary<string, RawRow<JsonNode>>();
+
+        /// <summary>
+        /// Get a row, deserialized to the given type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public RawRow<T>? GetRow<T>(string key) where T : class
+        {
+            if (Rows.TryGetValue(key, out var row))
+            {
+                return new RawRow<T>
+                {
+                    Key = row.Key,
+                    Columns = row.Columns.Deserialize<T>(Oryx.Cognite.Common.jsonOptions)!,
+                    LastUpdatedTime = row.LastUpdatedTime,
+                };
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Add a row to the table, serializing the columns from the given type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="columns"></param>
+        public void Add<T>(string key, T columns) where T : class
+        {
+            Rows[key] = new RawRow<JsonNode>
+            {
+                Key = key,
+                Columns = JsonSerializer.SerializeToNode(columns, Oryx.Cognite.Common.jsonOptions)!,
+                LastUpdatedTime = DateTime.UtcNow.ToUnixTimeMilliseconds(),
+            };
+        }
+
+        /// <summary>
+        /// List all rows, deserialized to the given type.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public IEnumerable<RawRow<T>> GetRows<T>() where T : class
+        {
+            foreach (var row in Rows.Values)
+            {
+                yield return new RawRow<T>
+                {
+                    Key = row.Key,
+                    Columns = row.Columns.Deserialize<T>(Oryx.Cognite.Common.jsonOptions)!,
+                    LastUpdatedTime = row.LastUpdatedTime,
+                };
+            }
+        }
+    }
+
     /// <summary>
     /// A mock for the CDF Raw API.
     /// </summary>
@@ -19,8 +87,8 @@ namespace Cognite.Extractor.Testing.Mock
         /// <summary>
         /// Representation of databases in mocked raw, map from (dbName, tableName) to rows in the table.
         /// </summary>
-        public Dictionary<(string, string), Dictionary<string, RawRow<JsonNode>>> Databases { get; }
-            = new Dictionary<(string, string), Dictionary<string, RawRow<JsonNode>>>();
+        public Dictionary<(string, string), RawTable> Databases { get; }
+            = new Dictionary<(string, string), RawTable>();
 
         /// <summary>
         /// Get the table if it exists.
@@ -29,13 +97,29 @@ namespace Cognite.Extractor.Testing.Mock
         /// <param name="dbName">Database name to get</param>
         /// <param name="tableName">Table name to get</param>
         /// <returns>Table, if it has been created.</returns>
-        public Dictionary<string, RawRow<JsonNode>>? GetTable(string dbName, string tableName)
+        public RawTable? GetTable(string dbName, string tableName)
         {
             if (Databases.TryGetValue((dbName, tableName), out var table))
             {
                 return table;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Get or create a raw table.
+        /// </summary>
+        /// <param name="dbName">Database name of table to get</param>
+        /// <param name="tableName">Table name to get</param>
+        /// <returns>Table, either new or already existing</returns>
+        public RawTable GetOrCreateTable(string dbName, string tableName)
+        {
+            if (!Databases.TryGetValue((dbName, tableName), out var table))
+            {
+                table = new RawTable();
+                Databases[(dbName, tableName)] = table;
+            }
+            return table;
         }
 
         /// <summary>
@@ -58,6 +142,15 @@ namespace Cognite.Extractor.Testing.Mock
         {
             return new SimpleMatcher("POST", _rawRowsRegexRaw, MockRawRows, times);
         }
+        /// <summary>
+        /// Get a matcher for the get raw rows endpoint.
+        /// </summary>
+        /// <param name="times"></param>
+        /// <returns></returns>
+        public RequestMatcher GetRawRowsMatcher(Times times)
+        {
+            return new SimpleMatcher("GET", _rawRowsRegexRaw, MockGetRawRows, times);
+        }
 
         private static string _rawRowsRegexRaw = @"/raw/dbs/([^/]+)/tables/([^/]+)/rows";
         private Regex _rawRowsRegex = new Regex(_rawRowsRegexRaw, RegexOptions.Compiled);
@@ -70,7 +163,7 @@ namespace Cognite.Extractor.Testing.Mock
             {
                 if (context.RawRequest.RequestUri.Query.Contains("ensureParent=true"))
                 {
-                    Databases[(dbName, tableName)] = new Dictionary<string, RawRow<JsonNode>>();
+                    Databases[(dbName, tableName)] = new RawTable();
                 }
                 else
                 {
@@ -84,7 +177,7 @@ namespace Cognite.Extractor.Testing.Mock
 
             foreach (var row in body!.Items)
             {
-                table[row.Key] = new RawRow<JsonNode>
+                table.Rows[row.Key] = new RawRow<JsonNode>
                 {
                     Key = row.Key,
                     Columns = row.Columns,
@@ -93,6 +186,30 @@ namespace Cognite.Extractor.Testing.Mock
             }
 
             return context.CreateJsonResponse(new EmptyResponse());
+        }
+
+        private HttpResponseMessage MockGetRawRows(RequestContext context, CancellationToken token)
+        {
+            var match = _rawRowsRegex.Match(context.RawRequest.RequestUri.AbsolutePath);
+            var dbName = match.Groups[1].Value;
+            var tableName = match.Groups[2].Value;
+            if (!Databases.TryGetValue((dbName, tableName), out var table))
+            {
+                return context.CreateError(System.Net.HttpStatusCode.BadRequest, "Table does not exist");
+            }
+
+            var query = context.ParseQuery();
+            var limit = int.Parse(query.ValueOrDefaultCompat("limit", "25"));
+            var cursor = int.Parse(query.ValueOrDefaultCompat("cursor", "0"));
+
+            var result = table.Rows.Values.Skip(cursor).Take(limit).ToList();
+            if (limit + cursor < table.Rows.Count)
+            {
+                // More data available
+                cursor += limit;
+                return context.CreateJsonResponse(new ItemsWithCursor<RawRow<JsonNode>> { Items = result, NextCursor = cursor.ToString() });
+            }
+            return context.CreateJsonResponse(new ItemsWithCursor<RawRow<JsonNode>> { Items = result });
         }
     }
 }

--- a/Cognite.Testing/Mock/Raw.cs
+++ b/Cognite.Testing/Mock/Raw.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Extractor.Common;
+using CogniteSdk;
+using Moq;
+
+namespace Cognite.Extractor.Testing.Mock
+{
+    /// <summary>
+    /// A mock for the CDF Raw API.
+    /// </summary>
+    public class RawMock
+    {
+        /// <summary>
+        /// Representation of databases in mocked raw, map from (dbName, tableName) to rows in the table.
+        /// </summary>
+        public Dictionary<(string, string), Dictionary<string, RawRow<JsonNode>>> Databases { get; }
+            = new Dictionary<(string, string), Dictionary<string, RawRow<JsonNode>>>();
+
+        /// <summary>
+        /// Get the table if it exists.
+        /// Returns null if it does not.
+        /// </summary>
+        /// <param name="dbName">Database name to get</param>
+        /// <param name="tableName">Table name to get</param>
+        /// <returns>Table, if it has been created.</returns>
+        public Dictionary<string, RawRow<JsonNode>>? GetTable(string dbName, string tableName)
+        {
+            if (Databases.TryGetValue((dbName, tableName), out var table))
+            {
+                return table;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Check if the table exists.
+        /// </summary>
+        /// <param name="dbName">Database name to check</param>
+        /// <param name="tableName">Table name to check</param>
+        /// <returns>True if the table exists, false otherwise.</returns>
+        public bool HasTable(string dbName, string tableName)
+        {
+            return Databases.ContainsKey((dbName, tableName));
+        }
+
+        /// <summary>
+        /// Get a matcher for the create raw rows endpoint.
+        /// </summary>
+        /// <param name="times">Expected number of times called.</param>
+        /// <returns>The created matcher.</returns>
+        public RequestMatcher CreateRawRowsMatcher(Times times)
+        {
+            return new SimpleMatcher("POST", _rawRowsRegexRaw, MockRawRows, times);
+        }
+
+        private static string _rawRowsRegexRaw = @"/raw/dbs/([^/]+)/tables/([^/]+)/rows";
+        private Regex _rawRowsRegex = new Regex(_rawRowsRegexRaw, RegexOptions.Compiled);
+        private async Task<HttpResponseMessage> MockRawRows(RequestContext context, CancellationToken token)
+        {
+            var match = _rawRowsRegex.Match(context.RawRequest.RequestUri.AbsolutePath);
+            var dbName = match.Groups[1].Value;
+            var tableName = match.Groups[2].Value;
+            if (!Databases.ContainsKey((dbName, tableName)))
+            {
+                if (context.RawRequest.RequestUri.Query.Contains("ensureParent=true"))
+                {
+                    Databases[(dbName, tableName)] = new Dictionary<string, RawRow<JsonNode>>();
+                }
+                else
+                {
+                    return context.CreateError(System.Net.HttpStatusCode.BadRequest, "Table does not exist");
+                }
+            }
+
+            var table = Databases[(dbName, tableName)];
+
+            var body = await context.ReadJsonBody<ItemsWithoutCursor<RawRowCreate<JsonNode>>>().ConfigureAwait(false);
+
+            foreach (var row in body!.Items)
+            {
+                table[row.Key] = new RawRow<JsonNode>
+                {
+                    Key = row.Key,
+                    Columns = row.Columns,
+                    LastUpdatedTime = DateTime.UtcNow.ToUnixTimeMilliseconds(),
+                };
+            }
+
+            return context.CreateJsonResponse(new EmptyResponse());
+        }
+    }
+}

--- a/Cognite.Testing/TestUtils.cs
+++ b/Cognite.Testing/TestUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -170,6 +171,29 @@ namespace Cognite.Extractor.Testing
             Random random = new Random();
             return prefix + new string(Enumerable.Repeat(chars, numChars)
               .Select(s => s[random.Next(s.Length)]).ToArray());
+        }
+
+        /// <summary>
+        /// Get value from dictionary or default (null).
+        /// 
+        /// This isn't available in .NET Standard 2.0, so we
+        /// provide a compatibility implementation here.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="dict"></param>
+        /// <param name="key"></param>
+        /// <param name="defaultValue">Default value to use</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static T? ValueOrDefaultCompat<T>(this Dictionary<string, T> dict, string key, T? defaultValue = default) where T : class
+        {
+            if (dict == null) throw new ArgumentNullException(nameof(dict));
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (dict.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+            return defaultValue;
         }
     }
 }

--- a/ExtractorUtils.Test/unit/CdfRawTest.cs
+++ b/ExtractorUtils.Test/unit/CdfRawTest.cs
@@ -72,9 +72,9 @@ namespace ExtractorUtils.Test.Unit
                 var table = raw.Databases[(_dbName, _tableName)];
                 foreach (var kvp in rows)
                 {
-                    Assert.True(table.TryGetValue(kvp.Key, out var dto));
-                    Assert.Equal(kvp.Value.Name, dto.Columns["name"].GetValue<string>());
-                    Assert.Equal(kvp.Value.Number, dto.Columns["number"].GetValue<int>());
+                    var row = table.GetRow<TestDto>(kvp.Key);
+                    Assert.Equal(kvp.Value.Name, row.Columns.Name);
+                    Assert.Equal(kvp.Value.Number, row.Columns.Number);
                 }
             }
 
@@ -168,9 +168,8 @@ namespace ExtractorUtils.Test.Unit
             var table = raw.Databases[(_dbName, _tableName)];
             for (int i = 0; i < index; ++i)
             {
-                Assert.True(table.TryGetValue($"r{i}", out var dto));
-                _output.WriteLine($"Row r{i}: {dto.Columns.ToJsonString()}");
-                Assert.Equal(i, dto.Columns["number"].GetValue<int>());
+                var row = table.GetRow<TestDto>($"r{i}");
+                Assert.Equal(i, row.Columns.Number);
             }
 
             System.IO.File.Delete(path);


### PR DESCRIPTION
Changes our existing raw tests to use the new CdfMock framework.

While this doesn't have a huge impact on the code here, except maybe make the test files a little cleaner, it _does_ have the advantage that the mocks we create here are effectively tested and verified mocks that can be reused in extractors. It makes sense to do this for certain key APIs.

The diff is positive mostly due to a bunch of utilities to make this easier.