### PR TITLE
Add support for State Sets

### DIFF
--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
-    <PackageReference Include="CogniteSdk" Version="5.10.0" />
+    <PackageReference Include="CogniteSdk" Version="5.12.3" />
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />

--- a/Cognite.Extensions/CogniteUtils.cs
+++ b/Cognite.Extensions/CogniteUtils.cs
@@ -667,6 +667,7 @@ namespace Cognite.Extensions
             StreamRecordExtensions.SetLogger(logger);
             DataModelUtils.SetLogger(logger);
             DataPointExtensionsWithInstanceId.SetLogger(logger);
+            DataModels.CogniteExtractorExtensions.BetaResourceExtensions.SetLogger(logger);
         }
     }
 

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Extractor.Common;
+using CogniteSdk;
+using CogniteSdk.DataModels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Prometheus;
+
+namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
+{
+    /// <summary>
+    /// Retrieves instances by id for the beta CDM resource wrapped by a <see cref="BetaResourceExtensions"/> method.
+    /// </summary>
+    internal delegate Task<IEnumerable<SourcedNode<T>>> RetrieveInstancesFunc<T>(IEnumerable<InstanceIdentifierWithType> ids, CancellationToken token);
+
+    /// <summary>
+    /// Upserts instances for the beta CDM resource wrapped by a <see cref="BetaResourceExtensions"/> method.
+    /// </summary>
+    internal delegate Task<IEnumerable<SlimInstance>> UpsertInstancesFunc<T>(IEnumerable<SourcedNodeWrite<T>> items, CancellationToken token);
+
+    /// <summary>
+    /// Sanitizes a batch of instance writes for the beta CDM resource wrapped by a <see cref="BetaResourceExtensions"/> method.
+    /// </summary>
+    internal delegate (IEnumerable<SourcedNodeWrite<T>>, IEnumerable<CogniteError<SourcedNodeWrite<T>>>) SanitizeInstancesFunc<T>(IEnumerable<SourcedNodeWrite<T>> items, SanitationMode mode);
+
+    /// <summary>
+    /// Shared get-or-create implementation for beta CDM resources
+    /// (<see cref="CogniteSdk.Resources.Beta.StateSetsResource"/>, <see cref="CogniteSdk.Resources.Beta.TimeSeriesResource"/>).
+    /// These resources do not implement <c>BaseDataModelResource&lt;T&gt;</c>, so they cannot use the
+    /// generic implementation in <see cref="Cognite.Extensions.DataModels.DataModelUtils"/>; instead
+    /// <see cref="BetaStateSetsExtensions"/> is a thin public wrapper that supplies its resource's
+    /// retrieve/upsert/sanitize operations to the methods here.
+    /// </summary>
+    internal static class BetaResourceExtensions
+    {
+        private static ILogger _logger = new NullLogger<Client>();
+
+        internal static void SetLogger(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public static Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateAsync<T>(
+            ViewIdentifier view,
+            RetrieveInstancesFunc<T> retrieve,
+            UpsertInstancesFunc<T> upsert,
+            SanitizeInstancesFunc<T> sanitize,
+            IEnumerable<InstanceIdentifier> instanceIds,
+            Func<IEnumerable<InstanceIdentifier>, IEnumerable<SourcedNodeWrite<T>>> buildItems,
+            BetaResourceParams options,
+            CancellationToken token)
+        {
+            Task<IEnumerable<SourcedNodeWrite<T>>> AsyncBuildItems(IEnumerable<InstanceIdentifier> ids)
+            {
+                return Task.FromResult(buildItems(ids));
+            }
+            return GetOrCreateAsync(view, retrieve, upsert, sanitize, instanceIds, AsyncBuildItems, options, token);
+        }
+
+        public static async Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateAsync<T>(
+            ViewIdentifier view,
+            RetrieveInstancesFunc<T> retrieve,
+            UpsertInstancesFunc<T> upsert,
+            SanitizeInstancesFunc<T> sanitize,
+            IEnumerable<InstanceIdentifier> instanceIds,
+            Func<IEnumerable<InstanceIdentifier>, Task<IEnumerable<SourcedNodeWrite<T>>>> buildItems,
+            BetaResourceParams options,
+            CancellationToken token)
+        {
+            var chunks = instanceIds
+                .ChunkBy(options.ChunkSize)
+                .ToList();
+            if (!chunks.Any()) return new CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>(null, null);
+
+            var results = new CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>[chunks.Count];
+
+            var generators = chunks
+                .Select<IEnumerable<InstanceIdentifier>, Func<Task>>(
+                    (chunk, idx) => async () =>
+                    {
+                        results[idx] = await GetOrCreateChunk(view, retrieve, upsert, sanitize, chunk,
+                            buildItems, 0, options, token).ConfigureAwait(false);
+                    });
+
+            await generators.RunThrottled(options.ThrottleSize, token).ConfigureAwait(false);
+
+            return CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>.Merge(results);
+        }
+
+        private static async Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateChunk<T>(
+            ViewIdentifier view,
+            RetrieveInstancesFunc<T> retrieve,
+            UpsertInstancesFunc<T> upsert,
+            SanitizeInstancesFunc<T> sanitize,
+            IEnumerable<InstanceIdentifier> instanceIds,
+            Func<IEnumerable<InstanceIdentifier>, Task<IEnumerable<SourcedNodeWrite<T>>>> buildItems,
+            int backoff,
+            BetaResourceParams options,
+            CancellationToken token)
+        {
+            IEnumerable<SourcedNode<T>> found;
+            using (CdfMetrics.Instances(view, "retrieve").NewTimer())
+            {
+                try
+                {
+                    found = await retrieve(
+                        instanceIds.Select(x => new InstanceIdentifierWithType(InstanceType.node, x)), token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    var err = ResultHandlers.ParseSimpleError<SourcedNodeWrite<T>>(ex, instanceIds?.Select(x => Identity.Create(x)), null);
+                    return new CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>(new[] { err }, null);
+                }
+            }
+
+            var missing = instanceIds.Except(found.Select(ts => new InstanceIdentifier(ts.Space, ts.ExternalId))).ToList();
+
+            if (missing.Count == 0)
+            {
+                return new CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>(null, found);
+            }
+
+            var toCreate = await buildItems(missing).ConfigureAwait(false);
+
+            IEnumerable<CogniteError<SourcedNodeWrite<T>>> errors;
+            (toCreate, errors) = sanitize(toCreate, options.SanitationMode);
+
+            var result = await CreateHandleErrors(view, upsert, toCreate, options.RetryMode, token).ConfigureAwait(false);
+            result.Results = result.Results == null ? found : result.Results.Concat(found);
+
+            if (errors.Any())
+            {
+                result.Errors = result.Errors == null ? errors : result.Errors.Concat(errors);
+            }
+
+            if (result.Errors == null || !result.Errors.Any()
+                || options.RetryMode != RetryMode.OnErrorKeepDuplicates
+                && options.RetryMode != RetryMode.OnFatalKeepDuplicates) return result;
+
+            var duplicateErrors = (result.Errors ?? Enumerable.Empty<CogniteError>()).Where(err =>
+                err.Resource == ResourceType.ExternalId
+                && err.Type == ErrorType.ItemExists)
+                .ToList();
+
+            var duplicatedIds = new HashSet<InstanceIdentifier>();
+            if (duplicateErrors.Any())
+            {
+                foreach (var error in duplicateErrors)
+                {
+                    if (error.Values == null || !error.Values.Any()) continue;
+                    foreach (var idt in error.Values) duplicatedIds.Add(idt.InstanceId);
+                }
+            }
+
+            if (!duplicatedIds.Any()) return result;
+            if (backoff == 3)
+            {
+                // We should never reach here anyway. The duplicates are objects that were created between
+                // retrieve and CreateHandleErrors call. If there are persistent duplicates, we will just return
+                // the results as is.
+                _logger.LogError("Failed to resolve {Count} duplicated instance ids in view {View} after {Backoff} retries, giving up",
+                    duplicatedIds.Count, view.ExternalId, backoff);
+                return result;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(0.1 * Math.Pow(2, backoff)), token).ConfigureAwait(false);
+            var nextResult = await GetOrCreateChunk(view, retrieve, upsert, sanitize, duplicatedIds,
+                buildItems, backoff + 1, options, token)
+                .ConfigureAwait(false);
+            result = result.Merge(nextResult);
+
+            return result;
+        }
+
+        private static async Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> CreateHandleErrors<T>(
+            ViewIdentifier view,
+            UpsertInstancesFunc<T> upsert,
+            IEnumerable<SourcedNodeWrite<T>> toCreate,
+            RetryMode retryMode,
+            CancellationToken token)
+        {
+            var errors = new List<CogniteError<SourcedNodeWrite<T>>>();
+            while (toCreate != null && toCreate.Any() && !token.IsCancellationRequested)
+            {
+                try
+                {
+                    IEnumerable<SlimInstance> newInstances;
+                    using (CdfMetrics.Instances(view, "create").NewTimer())
+                    {
+                        newInstances = await upsert(toCreate, token).ConfigureAwait(false);
+                    }
+
+                    var toCreateDict = new Dictionary<InstanceIdentifier, T>();
+                    foreach (var cr in toCreate)
+                    {
+                        toCreateDict[new InstanceIdentifier(cr.Space, cr.ExternalId)] = cr.Properties;
+                    }
+
+                    return new CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>(
+                        errors,
+                        newInstances.Select(x =>
+                        {
+                            var id = new InstanceIdentifier(x.Space, x.ExternalId);
+                            toCreateDict.TryGetValue(id, out var props);
+                            return new SourcedNode<T>(x, props);
+                        }));
+                }
+                catch (Exception ex)
+                {
+                    var error = ResultHandlers.ParseException<SourcedNodeWrite<T>>(ex, RequestType.UpsertInstances);
+                    if (error.Type == ErrorType.FatalFailure
+                        && (retryMode == RetryMode.OnFatal
+                            || retryMode == RetryMode.OnFatalKeepDuplicates))
+                    {
+                        await Task.Delay(1000, token).ConfigureAwait(false);
+                    }
+                    else if (retryMode == RetryMode.None)
+                    {
+                        errors.Add(error);
+                        break;
+                    }
+                    else
+                    {
+                        errors.Add(error);
+                        toCreate = await ResultHandlers.CleanFromError(error, toCreate, token).ConfigureAwait(false);
+                    }
+                }
+            }
+            return new CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>(errors, null);
+        }
+    }
+}

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
@@ -44,6 +44,20 @@ namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
             _logger = logger;
         }
 
+        /// <summary>
+        /// Gets instances for the beta CDM resource. If any instances are missing,
+        /// they will be created using the provided <see paramref="buildItems"/> function.
+        /// </summary>
+        /// <typeparam name="T">The type of the instance properties.</typeparam>
+        /// <param name="view">The view to retrieve instances from.</param>
+        /// <param name="retrieve">The function to retrieve instances.</param>
+        /// <param name="upsert">The function to upsert instances.</param>
+        /// <param name="sanitize">The function to sanitize instances.</param>
+        /// <param name="instanceIds">The ids of the instances to retrieve or create.</param>
+        /// <param name="buildItems">The function to build instances to create.</param>
+        /// <param name="options">The options for the get-or-create operation.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing the retrieved or created instances and any errors that occurred during the operation.</returns>
         public static Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateAsync<T>(
             ViewIdentifier view,
             RetrieveInstancesFunc<T> retrieve,

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
@@ -62,7 +62,8 @@ namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
         }
 
         /// <summary>
-        /// Retrieves instances by id for the beta CDM resource wrapped by a <see cref="BetaResourceExtensions"/> method. If any instances are missing, they will be created using the provided <see cref="buildItems"/> function.
+        /// Retrieves instances by id for the beta CDM resource wrapped by a <see cref="BetaResourceExtensions"/> method. If any instances are missing,
+        /// they will be created using the provided <see paramref="buildItems"/> function.
         /// </summary>
         /// <typeparam name="T">The type of the instance properties.</typeparam>
         /// <param name="view">The view to retrieve instances from.</param>

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceExtensions.cs
@@ -61,6 +61,19 @@ namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
             return GetOrCreateAsync(view, retrieve, upsert, sanitize, instanceIds, AsyncBuildItems, options, token);
         }
 
+        /// <summary>
+        /// Retrieves instances by id for the beta CDM resource wrapped by a <see cref="BetaResourceExtensions"/> method. If any instances are missing, they will be created using the provided <see cref="buildItems"/> function.
+        /// </summary>
+        /// <typeparam name="T">The type of the instance properties.</typeparam>
+        /// <param name="view">The view to retrieve instances from.</param>
+        /// <param name="retrieve">The function to retrieve instances.</param>
+        /// <param name="upsert">The function to upsert instances.</param>
+        /// <param name="sanitize">The function to sanitize instances.</param>
+        /// <param name="instanceIds">The ids of the instances to retrieve or create.</param>
+        /// <param name="buildItems">The function to build instances to create.</param>
+        /// <param name="options">The options for the get-or-create operation.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing the retrieved or created instances and any errors that occurred during the operation.</returns>
         public static async Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateAsync<T>(
             ViewIdentifier view,
             RetrieveInstancesFunc<T> retrieve,

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceParams.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceParams.cs
@@ -1,0 +1,45 @@
+namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
+{
+    /// <summary>
+    /// Bundles the chunking, throttling, retry, and sanitation parameters shared by the
+    /// beta CDM state-set and time-series extension methods (<see cref="BetaStateSetsExtensions"/>,
+    /// <see cref="BetaTimeSeriesExtensions"/>).
+    /// </summary>
+    public sealed class BetaResourceParams
+    {
+        /// <summary>
+        /// Maximum number of items per request.
+        /// </summary>
+        public int ChunkSize { get; }
+
+        /// <summary>
+        /// Maximum number of parallel requests.
+        /// </summary>
+        public int ThrottleSize { get; }
+
+        /// <summary>
+        /// How to handle failed requests.
+        /// </summary>
+        public RetryMode RetryMode { get; }
+
+        /// <summary>
+        /// The type of sanitation to apply before sending requests.
+        /// </summary>
+        public SanitationMode SanitationMode { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="BetaResourceParams"/>.
+        /// </summary>
+        /// <param name="chunkSize">Maximum number of items per request</param>
+        /// <param name="throttleSize">Maximum number of parallel requests</param>
+        /// <param name="retryMode">How to handle failed requests</param>
+        /// <param name="sanitationMode">The type of sanitation to apply before sending requests</param>
+        public BetaResourceParams(int chunkSize, int throttleSize, RetryMode retryMode, SanitationMode sanitationMode)
+        {
+            ChunkSize = chunkSize;
+            ThrottleSize = throttleSize;
+            RetryMode = retryMode;
+            SanitationMode = sanitationMode;
+        }
+    }
+}

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceParams.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaResourceParams.cs
@@ -2,8 +2,7 @@ namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
 {
     /// <summary>
     /// Bundles the chunking, throttling, retry, and sanitation parameters shared by the
-    /// beta CDM state-set and time-series extension methods (<see cref="BetaStateSetsExtensions"/>,
-    /// <see cref="BetaTimeSeriesExtensions"/>).
+    /// beta CDM state-set and time-series extension methods (<see cref="BetaStateSetsExtensions"/>).
     /// </summary>
     public sealed class BetaResourceParams
     {

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaStateSetsExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaStateSetsExtensions.cs
@@ -35,6 +35,7 @@ namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
             BetaResourceParams options,
             CancellationToken token) where T : CogniteStateSet
         {
+            if (options == null) throw new ArgumentNullException(nameof(options));
             return BetaResourceExtensions.GetOrCreateAsync(
                 StateSetsResource.View,
                 (ids, tok) => stateSets.RetrieveAsync<T>(ids, tok),

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaStateSetsExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/BetaStateSetsExtensions.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CogniteSdk;
+using CogniteSdk.DataModels;
+using CogniteSdk.DataModels.Core;
+using CogniteSdk.Resources.Beta;
+
+namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
+{
+    /// <summary>
+    /// Extension methods for creating and managing state sets through the beta CDM state set
+    /// resource. State sets are currently only available through this beta API. These are thin
+    /// wrappers around <see cref="BetaResourceExtensions"/>.
+    /// </summary>
+    public static class BetaStateSetsExtensions
+    {
+        /// <summary>
+        /// Get or create the state sets with the provided <paramref name="instanceIds"/> if they exist in CDF.
+        /// If one or more do not exist, use the <paramref name="buildStateSets"/> function to construct
+        /// the missing state set objects and upload them to CDF using the chunking and throttling in
+        /// <paramref name="options"/>.
+        /// </summary>
+        /// <param name="stateSets">CogniteSdk beta CDM StateSets resource</param>
+        /// <param name="instanceIds">Instance Ids</param>
+        /// <param name="buildStateSets">Function that builds CogniteSdk SourcedNodeWrite objects</param>
+        /// <param name="options">Chunking, throttling, retry, and sanitation options</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found state sets</returns>
+        public static Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateStateSetsAsync<T>(
+            this StateSetsResource stateSets,
+            IEnumerable<InstanceIdentifier> instanceIds,
+            Func<IEnumerable<InstanceIdentifier>, IEnumerable<SourcedNodeWrite<T>>> buildStateSets,
+            BetaResourceParams options,
+            CancellationToken token) where T : CogniteStateSet
+        {
+            return BetaResourceExtensions.GetOrCreateAsync(
+                StateSetsResource.View,
+                (ids, tok) => stateSets.RetrieveAsync<T>(ids, tok),
+                (items, tok) => stateSets.UpsertAsync(items, null, tok),
+                DataModelSanitation.CleanInstanceRequest,
+                instanceIds, buildStateSets, options, token);
+        }
+
+        /// <summary>
+        /// Get or create the state sets with the provided <paramref name="instanceIds"/> if they exist in CDF.
+        /// If one or more do not exist, use the <paramref name="buildStateSets"/> function to construct
+        /// the missing state set objects and upload them to CDF using the chunking and throttling in
+        /// <paramref name="options"/>.
+        /// </summary>
+        /// <param name="stateSets">CogniteSdk beta CDM StateSets resource</param>
+        /// <param name="instanceIds">Instance Ids</param>
+        /// <param name="buildStateSets">Async function that builds CogniteSdk SourcedNodeWrite objects</param>
+        /// <param name="options">Chunking, throttling, retry, and sanitation options</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A <see cref="CogniteResult{TResult, TError}"/> containing errors that occured and a list of the created and found state sets</returns>
+        public static Task<CogniteResult<SourcedNode<T>, SourcedNodeWrite<T>>> GetOrCreateStateSetsAsync<T>(
+            this StateSetsResource stateSets,
+            IEnumerable<InstanceIdentifier> instanceIds,
+            Func<IEnumerable<InstanceIdentifier>, Task<IEnumerable<SourcedNodeWrite<T>>>> buildStateSets,
+            BetaResourceParams options,
+            CancellationToken token) where T : CogniteStateSet
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            return BetaResourceExtensions.GetOrCreateAsync(
+                StateSetsResource.View,
+                (ids, tok) => stateSets.RetrieveAsync<T>(ids, tok),
+                (items, tok) => stateSets.UpsertAsync(items, null, tok),
+                DataModelSanitation.CleanInstanceRequest,
+                instanceIds, buildStateSets, options, token);
+        }
+    }
+}

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/DataPointExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/DataPointExtensions.cs
@@ -94,7 +94,7 @@ namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
                 {
                     Space = id.InstanceId.Space,
                     ExternalId = id.InstanceId.ExternalId,
-                    Properties = new CogniteTimeSeriesBase() { Type = isString ? TimeSeriesType.String : TimeSeriesType.Numeric }
+                    Properties = new CogniteTimeSeriesBase() { Type = isString ? CogniteSdk.DataModels.Core.TimeSeriesType.String : CogniteSdk.DataModels.Core.TimeSeriesType.Numeric }
                 });
             }
 

--- a/Cognite.Extensions/DataModels/InstancesResultHandlers.cs
+++ b/Cognite.Extensions/DataModels/InstancesResultHandlers.cs
@@ -70,5 +70,26 @@ namespace Cognite.Extensions
                 ts => ts.ExternalId == null || ts.Space == null ? null : Identity.Create(new InstanceIdentifier(ts.Space, ts.ExternalId)),
                 CdfMetrics.TimeSeriesSkipped);
         }
+
+        /// <summary>
+        /// List of SourceNodeWrite objects, offending objects removed from input items based on CogniteError.
+        /// Use this overload when there is no corresponding <see cref="BaseDataModelResource{T}"/> resource for
+        /// <typeparamref name="T"/> to query for underlying instances with (e.g. state sets), so there is no
+        /// type-immutability special case to apply.
+        /// </summary>
+        /// <param name="error">Error that occured with a previous push</param>
+        /// <param name="items">Nodes to clean</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Nodes that are not affected by the error</returns>
+        public static Task<IEnumerable<SourcedNodeWrite<T>>> CleanFromError<T>(
+            CogniteError<SourcedNodeWrite<T>> error,
+            IEnumerable<SourcedNodeWrite<T>> items,
+            CancellationToken token
+        )
+        {
+            return Task.FromResult(CleanFromErrorCommon(error!, items, IsAffected,
+                ts => ts.ExternalId == null || ts.Space == null ? null : Identity.Create(new InstanceIdentifier(ts.Space, ts.ExternalId)),
+                CdfMetrics.InstanceUpsertsSkipped));
+        }
     }
 }

--- a/ExtractorUtils.Test/integration/IDMTimeSeriesIntegrationTest.cs
+++ b/ExtractorUtils.Test/integration/IDMTimeSeriesIntegrationTest.cs
@@ -667,5 +667,70 @@ namespace ExtractorUtils.Test.Integration
                 await DeleteTimeseries(tester, tss.space, tss.externalIds);
             }
         }
+
+        /// <summary>
+        /// Exercises the beta CDM state-set get-or-create path (BetaStateSetsExtensions.GetOrCreateStateSetsAsync
+        /// / BetaResourceExtensions.GetOrCreateAsync) directly against the SDK resource, ahead of any
+        /// CogniteDestinationWithIDM convenience wrapper. An existing state set is seeded via the raw SDK
+        /// upsert call so this test does not depend on the beta upsert wrapper.
+        /// </summary>
+        [Theory]
+        [InlineData(CogniteHost.GreenField)]
+        [InlineData(CogniteHost.BlueField)]
+        public async Task TestStateSetsGetOrCreate(CogniteHost host)
+        {
+            using var tester = new CDFTester(host, _output);
+            var spaceId = await tester.GetSpaceId();
+            var existingXid = $"{tester.Prefix}utils-test-state-set-existing";
+            var newXid = $"{tester.Prefix}utils-test-state-set-new";
+            var stateSets = tester.DestinationWithIDM.CogniteClient.Beta.StateSets;
+            var options = new BetaResourceParams(1000, 1, RetryMode.OnError, SanitationMode.Clean);
+
+            try
+            {
+                var seedResult = await stateSets.UpsertAsync(new[]
+                {
+                    new SourcedNodeWrite<CogniteStateSet>
+                    {
+                        Space = spaceId,
+                        ExternalId = existingXid,
+                        Properties = new CogniteStateSet
+                        {
+                            Name = existingXid,
+                            States = new[] { new CogniteState { NumericValue = 0, StringValue = "CLOSED" } }
+                        }
+                    }
+                }, null, tester.Source.Token);
+                Assert.Single(seedResult);
+
+                var result = await stateSets.GetOrCreateStateSetsAsync<CogniteStateSet>(
+                    new[] { new InstanceIdentifier(spaceId, existingXid), new InstanceIdentifier(spaceId, newXid) },
+                    missing =>
+                    {
+                        var missingId = Assert.Single(missing);
+                        Assert.Equal(newXid, missingId.ExternalId);
+                        return new[]
+                        {
+                            new SourcedNodeWrite<CogniteStateSet>
+                            {
+                                Space = missingId.Space,
+                                ExternalId = missingId.ExternalId,
+                                Properties = new CogniteStateSet
+                                {
+                                    Name = newXid,
+                                    States = new[] { new CogniteState { NumericValue = 0, StringValue = "IDLE" } }
+                                }
+                            }
+                        };
+                    },
+                    options, tester.Source.Token);
+                result.Throw();
+                Assert.Equal(2, result.Results.Count());
+            }
+            finally
+            {
+                await DeleteTimeseries(tester, spaceId, new[] { existingXid, newXid });
+            }
+        }
     }
 }


### PR DESCRIPTION
CDF now supports a first-class CogniteTimeSeries.type = "state" that stores both a numericValue and a stringValue on every data point and links the time series to a CogniteStateSet node that catalogs the valid states. 

This PR adds support to allow downstream extractors to create CogniteStateSet, and adds generic helper functions to CRUD beta resources