### PR TITLE
 Limit wait time for queue elements

### DIFF
--- a/Cognite.Common/TaskThrottler.cs
+++ b/Cognite.Common/TaskThrottler.cs
@@ -92,7 +92,7 @@ namespace Cognite.Extractor.Common
         private readonly bool _keepAllResults;
 
         private int _taskIndex;
-        private const int DefaultWaitTime = 30 * 1000; // 30 seconds
+        private long _waitTimeMs { get; set; } = TimeSpan.FromMinutes(5).Milliseconds; // 5 minutes, default wait time for a new task to be scheduled before checking if we are done
 
         /// <summary>
         /// Constructor
@@ -104,11 +104,13 @@ namespace Cognite.Extractor.Common
         /// <param name="keepAllResults">Keep all task result objects, not those who have failed or are within the
         /// last <paramref name="timeUnit"/>. This means that the size in memory of the task throttler will grow forever,
         /// do not use this unless you intend to dispose of the throttler within a short period of time.</param>
+        /// <param name="waitTime">Time to wait for a new task to be scheduled before checking if we are done.
         public TaskThrottler(int maxParallelism,
             bool quitOnFailure = false,
             int perUnit = 0,
             TimeSpan? timeUnit = null,
-            bool keepAllResults = false)
+            bool keepAllResults = false,
+            long waitTime = 0)
         {
             _maxParallelism = maxParallelism;
             _maxPerUnit = perUnit;
@@ -126,6 +128,7 @@ namespace Cognite.Extractor.Common
             _quitOnFailure = quitOnFailure;
             _completionSource = CancellationTokenSource.CreateLinkedTokenSource(_source.Token);
             _keepAllResults = keepAllResults;
+            _waitTimeMs = waitTime > 0 ? waitTime : _waitTimeMs;
             RunTask = Task.Run(async () => await Run().ConfigureAwait(false));
         }
 
@@ -280,9 +283,9 @@ namespace Cognite.Extractor.Common
                 {
                     try
                     {
-                        // Wait for upto DefaultWaitTime for a new task to be scheduled, if none is scheduled,
+                        // Wait for upto waitTimeMs for a new task to be scheduled, if none is scheduled,
                         // we will move ahead and check if we are done.
-                        var generator = _generators.TryTake(out var item, DefaultWaitTime, token) ? item : null;
+                        var generator = _generators.TryTake(out var item, (int)_waitTimeMs, token) ? item : null;
                         if (generator != null)
                         {
                             lock (_lock)

--- a/Cognite.Common/TaskThrottler.cs
+++ b/Cognite.Common/TaskThrottler.cs
@@ -92,7 +92,7 @@ namespace Cognite.Extractor.Common
         private readonly bool _keepAllResults;
 
         private int _taskIndex;
-        private const int DefaultWaitTime = 5 * 60 * 1000; // 5 minutes
+        private const int DefaultWaitTime = 30 * 1000; // 30 seconds
 
         /// <summary>
         /// Constructor

--- a/Cognite.Common/TaskThrottler.cs
+++ b/Cognite.Common/TaskThrottler.cs
@@ -58,9 +58,9 @@ namespace Cognite.Extractor.Common
     /// <summary>
     /// Tool to throttle the execution of tasks based on max perallelism, and max number of tasks
     /// scheduled per time unit.
-    /// 
+    ///
     /// Maximum parallelism simply limits the number of parallel tasks.
-    /// 
+    ///
     /// Per unit sets the maximum number of tasks scheduled per time unit.
     ///
     /// Tasks are enqueued and scheduled for execution in order.
@@ -92,6 +92,7 @@ namespace Cognite.Extractor.Common
         private readonly bool _keepAllResults;
 
         private int _taskIndex;
+        private const int DefaultWaitTime = 5 * 60 * 1000; // 5 minutes
 
         /// <summary>
         /// Constructor
@@ -279,10 +280,15 @@ namespace Cognite.Extractor.Common
                 {
                     try
                     {
-                        var generator = _generators.Take(token);
-                        lock (_lock)
+                        // Wait for upto DefaultWaitTime for a new task to be scheduled, if none is scheduled,
+                        // we will move ahead and check if we are done.
+                        var generator = _generators.TryTake(out var item, DefaultWaitTime, token) ? item : null;
+                        if (generator != null)
                         {
-                            _runningTasks.Add(generator());
+                            lock (_lock)
+                            {
+                                _runningTasks.Add(generator());
+                            }
                         }
                     }
                     catch (InvalidOperationException)

--- a/Cognite.Common/TaskThrottler.cs
+++ b/Cognite.Common/TaskThrottler.cs
@@ -92,7 +92,7 @@ namespace Cognite.Extractor.Common
         private readonly bool _keepAllResults;
 
         private int _taskIndex;
-        private long _waitTimeMs { get; set; } = TimeSpan.FromMinutes(5).Milliseconds; // 5 minutes, default wait time for a new task to be scheduled before checking if we are done
+        private long _waitTimeMs { get; set; } = (long)TimeSpan.FromMinutes(5).TotalMilliseconds; // 5 minutes, default wait time for a new task to be scheduled before checking if we are done
 
         /// <summary>
         /// Constructor
@@ -104,7 +104,7 @@ namespace Cognite.Extractor.Common
         /// <param name="keepAllResults">Keep all task result objects, not those who have failed or are within the
         /// last <paramref name="timeUnit"/>. This means that the size in memory of the task throttler will grow forever,
         /// do not use this unless you intend to dispose of the throttler within a short period of time.</param>
-        /// <param name="waitTime">Time to wait for a new task to be scheduled before checking if we are done.
+        /// <param name="waitTime">Time to wait for a new task to be scheduled before checking if we are done. </param>
         public TaskThrottler(int maxParallelism,
             bool quitOnFailure = false,
             int perUnit = 0,

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
-    <PackageReference Include="CogniteSdk" Version="5.10.0" />
+    <PackageReference Include="CogniteSdk" Version="5.11.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />

--- a/Cognite.Extensions/Cognite.Extensions.csproj
+++ b/Cognite.Extensions/Cognite.Extensions.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.79.2" />
-    <PackageReference Include="CogniteSdk" Version="5.11.0" />
+    <PackageReference Include="CogniteSdk" Version="5.12.1" />
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />

--- a/Cognite.Extensions/CogniteResult.cs
+++ b/Cognite.Extensions/CogniteResult.cs
@@ -15,8 +15,11 @@ namespace Cognite.Extensions
     {
         private static CogniteError<TError>? ParseCommonErrors<TError>(ResponseException ex)
         {
-            // Handle any common behavior here
-            if (ex.Code >= 500 || ex.Code != 400 && ex.Code != 422 && ex.Code != 409)
+            // Handle any common behavior here.
+            // 404 is included here so that per-type handlers (e.g. ParseSequenceRowException,
+            // which treats 404 as a missing-column error) actually get a chance to run instead of
+            // this generic fallback swallowing the response first.
+            if (ex.Code >= 500 || ex.Code != 400 && ex.Code != 404 && ex.Code != 422 && ex.Code != 409)
                 return new CogniteError<TError> { Message = ex.Message, Status = ex.Code, Exception = ex };
             return null;
         }

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/DataPointExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/DataPointExtensions.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Cognite.Extractor.Common;
 using CogniteSdk;
 using CogniteSdk.DataModels;
 using CogniteSdk.DataModels.Core;
+using CogniteSdk.Resources;
+using Com.Cognite.V1.Timeseries.Proto;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Prometheus;
+using TimeRange = Cognite.Extractor.Common.TimeRange;
 
 namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
 {

--- a/Cognite.Extensions/DataModels/CogniteExtractorExtensions/DataPointExtensions.cs
+++ b/Cognite.Extensions/DataModels/CogniteExtractorExtensions/DataPointExtensions.cs
@@ -1,21 +1,15 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Cognite.Extractor.Common;
 using CogniteSdk;
 using CogniteSdk.DataModels;
 using CogniteSdk.DataModels.Core;
-using CogniteSdk.Resources;
-using Com.Cognite.V1.Timeseries.Proto;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Prometheus;
-using TimeRange = Cognite.Extractor.Common.TimeRange;
 
 namespace Cognite.Extensions.DataModels.CogniteExtractorExtensions
 {

--- a/Cognite.Extensions/Sequences/SequenceExtensions.cs
+++ b/Cognite.Extensions/Sequences/SequenceExtensions.cs
@@ -376,6 +376,16 @@ namespace Cognite.Extensions
             IEnumerable<CogniteError<SequenceRowError>> errors;
             (toCreate, errors) = Sanitation.CleanSequenceDataRequest(toCreate, sanitationMode);
 
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                foreach (var err in errors)
+                {
+                    _logger.LogDebug(
+                        "Local sanitation produced error: resource {Resource}, type {Type}, skipped {Skipped}",
+                        err.Resource, err.Type, err.Skipped?.Count() ?? 0);
+                }
+            }
+
             var dict = toCreate.ToDictionary(create => create.Id.HasValue ? Identity.Create(create.Id.Value) : Identity.Create(create.ExternalId));
             var chunks = dict
                 .Select(kvp => (kvp.Key, kvp.Value.Rows))
@@ -447,7 +457,16 @@ namespace Cognite.Extensions
                 catch (Exception ex)
                 {
                     _logger.LogDebug("Failed to create rows for {seq} sequences", toCreate.Count());
+                    if (ex is ResponseException rex)
+                    {
+                        _logger.LogDebug(
+                            "CreateRowsAsync failed with code {Code}, message '{Message}', missing: {Missing}, duplicated: {Duplicated}",
+                            rex.Code, rex.Message, rex.Missing?.Count() ?? 0, rex.Duplicated?.Count() ?? 0);
+                    }
                     var error = ResultHandlers.ParseException<SequenceRowError>(ex, RequestType.CreateSequenceRows);
+                    _logger.LogDebug(
+                        "Parsed sequence row error as resource {Resource}, type {Type}, complete {Complete}, values: {Values}",
+                        error.Resource, error.Type, error.Complete, error.Values?.Count() ?? 0);
 
                     if (error.Type == ErrorType.FatalFailure
                         && (retryMode == RetryMode.OnFatal

--- a/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
+++ b/Cognite.Extensions/Sequences/SequenceResultHandlers.cs
@@ -77,22 +77,24 @@ namespace Cognite.Extensions
 
         private static void ParseSequenceRowException(ResponseException ex, CogniteError err)
         {
-            if (ex.Missing?.Any() ?? false)
+            var missingValues = ex.Missing?.Select(dict =>
+            {
+                if (dict.TryGetValue("id", out var idVal) && idVal is MultiValue.Long longVal)
+                {
+                    return Identity.Create(longVal.Value);
+                }
+                else if (dict.TryGetValue("externalId", out var extIdVal) && extIdVal is MultiValue.String stringVal)
+                {
+                    return Identity.Create(stringVal.Value);
+                }
+                return null!;
+            }).Where(id => id != null).ToList();
+
+            if (missingValues != null && missingValues.Count > 0)
             {
                 err.Type = ErrorType.ItemMissing;
                 err.Resource = ResourceType.Id;
-                err.Values = ex.Missing.Select(dict =>
-                {
-                    if (dict.TryGetValue("id", out var idVal) && idVal is MultiValue.Long longVal)
-                    {
-                        return Identity.Create(longVal.Value);
-                    }
-                    else if (dict.TryGetValue("externalId", out var extIdVal) && extIdVal is MultiValue.String stringVal)
-                    {
-                        return Identity.Create(stringVal.Value);
-                    }
-                    return null!;
-                }).Where(id => id != null);
+                err.Values = missingValues;
             }
             // Error messages are completely different in greenfield and bluefield
             else if (ex.Code == 400 && (ex.Message.StartsWith("error in sequence", StringComparison.InvariantCultureIgnoreCase)
@@ -106,6 +108,15 @@ namespace Cognite.Extensions
             {
                 err.Type = ErrorType.ItemMissing;
                 err.Resource = ResourceType.ColumnExternalId;
+                err.Complete = false;
+            }
+            else
+            {
+                // Nothing recognized -- including the case where ex.Missing was present but didn't
+                // map to a recognizable sequence identity. Leaving Complete at its default (true)
+                // with no Values would make CleanFromError treat the entire remaining batch as
+                // skipped by this one under-specified error, so fall back to local verification
+                // (VerifySequencesFromCDF) instead.
                 err.Complete = false;
             }
         }

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -250,10 +250,18 @@ namespace ExtractorUtils.Test.Unit
             Assert.Null(results[0].Exception);
         }
 
-        [Fact(Timeout = 10000)]
-        public async Task TestTaskThrottlerWaitForCompletionWithSingleFailingTask()
+        [Fact(Timeout = 40000)]
+        public async Task TestTaskThrottlerQuitsOnFailureEvenWhenIdleAfterScheduling()
         {
-            using var throttler = new TaskThrottler(1, true);
+            // maxParallelism=2 but only one task is ever enqueued. Once that task is dequeued and
+            // running, AllowSchedule() still returns true (1 running < 2 max), so the loop goes
+            // straight back to _generators.Take()/TryTake() on the now-empty queue instead of
+            // waiting on _taskCompletionEvent for the running task, since a parallelism slot is
+            // free. With the old unbounded _generators.Take(token), the loop then never returns
+            // from that wait, so it never notices the task fail and RunTask hangs forever. The
+            // bounded wait (DefaultWaitTime) lets the loop wake up on its own, see the failure via
+            // quitOnFailure, and complete.
+            using var throttler = new TaskThrottler(2, true);
 
             static Task badGenerator() => Task.Run(() =>
             {
@@ -263,11 +271,12 @@ namespace ExtractorUtils.Test.Unit
 
             throttler.EnqueueTask(badGenerator);
 
-            var completionTask = throttler.WaitForCompletion();
-            await RunWithTimeout(completionTask, 2000);
+            // Wait past DefaultWaitTime (30s) so the loop has time to wake up on its own and
+            // notice the failed task even though nothing else was ever scheduled.
+            var finished = await Task.WhenAny(throttler.RunTask, Task.Delay(35000));
 
-            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await completionTask);
-            Assert.Equal("Failed task", exception.Message);
+            Assert.Equal(throttler.RunTask, finished);
+            Assert.True(throttler.RunTask.IsCompleted);
         }
 
         [Theory]

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -229,6 +229,47 @@ namespace ExtractorUtils.Test.Unit
 
             await Assert.ThrowsAsync<AggregateException>(() => throttler2.EnqueueAndWait(badGenerator));
         }
+
+        [Fact(Timeout = 10000)]
+        public async Task TestTaskThrottlerWaitForCompletionWhenQueueBecomesIdle()
+        {
+            using var throttler = new TaskThrottler(1, keepAllResults: true);
+
+            await throttler.EnqueueAndWait(() => Task.Delay(100));
+
+            // Give the background loop time to start waiting for more work after the queued task completes.
+            await Task.Delay(100);
+
+            var completionTask = throttler.WaitForCompletion();
+            await RunWithTimeout(completionTask, 1000);
+
+            var results = (await completionTask).ToList();
+            Assert.Single(results);
+            Assert.Equal(0, results[0].Index);
+            Assert.True(results[0].IsCompleted);
+            Assert.Null(results[0].Exception);
+        }
+
+        [Fact(Timeout = 10000)]
+        public async Task TestTaskThrottlerWaitForCompletionWithSingleFailingTask()
+        {
+            using var throttler = new TaskThrottler(1, true);
+
+            static Task badGenerator() => Task.Run(() =>
+            {
+                SpinWait.SpinUntil(() => false, 200);
+                throw new InvalidOperationException("Failed task");
+            });
+
+            throttler.EnqueueTask(badGenerator);
+
+            var completionTask = throttler.WaitForCompletion();
+            await RunWithTimeout(completionTask, 2000);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await completionTask);
+            Assert.Equal("Failed task", exception.Message);
+        }
+
         [Theory]
         [InlineData(1, new[] { 3, 2, 1, 1 })]
         [InlineData(2, new[] { 3, 2, 2 })]

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -233,7 +233,7 @@ namespace ExtractorUtils.Test.Unit
         [Fact(Timeout = 10000)]
         public async Task TestTaskThrottlerWaitForCompletionWhenQueueBecomesIdle()
         {
-            using var throttler = new TaskThrottler(1, keepAllResults: true);
+            using var throttler = new TaskThrottler(1, keepAllResults: true, waitTime: TimeSpan.FromSeconds(5).Milliseconds);
 
             await throttler.EnqueueAndWait(() => Task.Delay(100));
 

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -233,7 +233,7 @@ namespace ExtractorUtils.Test.Unit
         [Fact(Timeout = 10000)]
         public async Task TestTaskThrottlerWaitForCompletionWhenQueueBecomesIdle()
         {
-            using var throttler = new TaskThrottler(1, keepAllResults: true, waitTime: TimeSpan.FromSeconds(5).Milliseconds);
+            using var throttler = new TaskThrottler(1, keepAllResults: true, waitTime: (long)TimeSpan.FromSeconds(5).TotalMilliseconds);
 
             await throttler.EnqueueAndWait(() => Task.Delay(100));
 
@@ -261,7 +261,7 @@ namespace ExtractorUtils.Test.Unit
             // from that wait, so it never notices the task fail and RunTask hangs forever. The
             // bounded wait (DefaultWaitTime) lets the loop wake up on its own, see the failure via
             // quitOnFailure, and complete.
-            using var throttler = new TaskThrottler(2, true, waitTime: TimeSpan.FromSeconds(5).Milliseconds);
+            using var throttler = new TaskThrottler(2, true, waitTime: (long)TimeSpan.FromSeconds(5).TotalMilliseconds);
 
             static Task badGenerator() => Task.Run(() =>
             {

--- a/ExtractorUtils.Test/unit/ChunkingTest.cs
+++ b/ExtractorUtils.Test/unit/ChunkingTest.cs
@@ -250,7 +250,7 @@ namespace ExtractorUtils.Test.Unit
             Assert.Null(results[0].Exception);
         }
 
-        [Fact(Timeout = 40000)]
+        [Fact(Timeout = 10000)]
         public async Task TestTaskThrottlerQuitsOnFailureEvenWhenIdleAfterScheduling()
         {
             // maxParallelism=2 but only one task is ever enqueued. Once that task is dequeued and
@@ -261,7 +261,7 @@ namespace ExtractorUtils.Test.Unit
             // from that wait, so it never notices the task fail and RunTask hangs forever. The
             // bounded wait (DefaultWaitTime) lets the loop wake up on its own, see the failure via
             // quitOnFailure, and complete.
-            using var throttler = new TaskThrottler(2, true);
+            using var throttler = new TaskThrottler(2, true, waitTime: TimeSpan.FromSeconds(5).Milliseconds);
 
             static Task badGenerator() => Task.Run(() =>
             {

--- a/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
+++ b/ExtractorUtils.Test/unit/Unstable/TaskSchedulerTest.cs
@@ -387,7 +387,7 @@ namespace ExtractorUtils.Test.unit.Unstable
             Assert.Empty(sink.TaskStart);
             Assert.Empty(sink.TaskEnd);
 
-            await Task.Delay(1000); // Ensure some time has passed
+            await Task.Delay(1050); // Ensure some time has passed
 
 
             // Task1 should have run, Task2 should not


### PR DESCRIPTION
This pull request updates the TaskThrottler to use a bounded wait (TryTake with a 30-second timeout) instead of an unbounded block when retrieving tasks from the queue, allowing the background loop to wake up and handle failures even when idle.

This helps prevent issues when the last task of the queue fails, like in https://cognitedata.atlassian.net/browse/CDFBUG-1584
