### PR TITLE
Migrate renovate config to extend Cognite config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "local>cognitedata/renovate-config-public"
   ],
   "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
Repositories in the cognitedata org should extend from the Cognite base renovate config.

This PR migrates from the default "config:base" to the Cognite base config for public repos.